### PR TITLE
Add macOS and python 3.7

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,11 +5,13 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6]
+        python-version: [3.6, 3.7]
+        os: [macos-latest, ubuntu-latest]
+
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Windows compatibility will take more work since there is no pypi package for pytorch but our project is already compatible with macOS so this PR adds it to the test cases. Same for python 3.7.