### PR TITLE
Implement evaluation metrics at 3D data scale

### DIFF
--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -769,6 +769,9 @@ def cmd_eval(context):
         results_pred['image_id'] = subj_acq
         df_results = df_results.append(results_pred, ignore_index=True)
 
+    df_results = df_results.set_index('image_id')
+    print(df_results.head())
+
     # save results as csv
     fname_out = os.path.join(path_results, 'evaluation_3Dmetrics.csv')
     df_results.to_csv(fname_out)

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -756,7 +756,10 @@ def cmd_eval(context):
         fname_gt = os.path.join(context['bids_path'], 'derivatives', 'labels', subj, 'anat', fname_gt)
 
         eval = Evaluation3DMetrics(fname_pred=fname_pred, fname_gt=fname_gt)
-        df_results = df_results.append(eval.get_all_metrics(), ignore_index=True)
+        results_pred = eval.get_all_metrics()
+
+        results_pred['image_id'] = subj_acq
+        df_results = df_results.append(results_pred, ignore_index=True)
         print(df_results.head())
 
 def run_main():

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -728,6 +728,11 @@ def cmd_test(context):
     metric_mgr.reset()
     print(metrics_dict)
 
+def cmd_eval(context):
+    ##### DEFINE DEVICE #####
+    device = torch.device("cpu")
+    print("Working on {}.".format(device))
+
 
 def run_main():
     if len(sys.argv) <= 1:
@@ -744,7 +749,8 @@ def run_main():
         shutil.copyfile(sys.argv[1], "./" + context["log_directory"] + "/config_file.json")
     elif command == 'test':
         cmd_test(context)
-
+    elif command == 'eval':
+        cmd_eval(context)
 
 if __name__ == "__main__":
     run_main()

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -745,9 +745,15 @@ def cmd_eval(context):
     if not os.path.isdir(path_results):
         os.makedirs(path_results)
 
+    # init data frame
     df_results = pd.DataFrame()
+
+    # list fname pred files
     path_pred = os.path.join(context['log_directory'], 'pred_masks')
-    for fname_pred in os.listdir(path_pred):
+    fname_pred_lst = os.listdir(path_pred)
+
+    # loop across fname pred files
+    for fname_pred in tqdm(fname_pred_lst, desc="Evaluation"):
         subj_acq = fname_pred.split('_pred.nii.gz')[0]
         fname_gt = subj_acq+context['target_suffix']+'.nii.gz'
         subj, acq = subj_acq.split('_')[0], '_'.join(subj_acq.split('_')[1:])
@@ -755,12 +761,15 @@ def cmd_eval(context):
         fname_pred = os.path.join(path_pred, fname_pred)
         fname_gt = os.path.join(context['bids_path'], 'derivatives', 'labels', subj, 'anat', fname_gt)
 
+        # 3D evaluation
         eval = Evaluation3DMetrics(fname_pred=fname_pred, fname_gt=fname_gt)
         results_pred = eval.get_all_metrics()
 
+        # save results of this fname_pred
         results_pred['image_id'] = subj_acq
         df_results = df_results.append(results_pred, ignore_index=True)
 
+    # save results as csv
     fname_out = os.path.join(path_results, 'evaluation_3Dmetrics.csv')
     df_results.to_csv(fname_out)
 

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -5,6 +5,7 @@ import time
 import shutil
 import random
 import joblib
+import pandas as pd
 from math import exp
 import numpy as np
 
@@ -744,10 +745,19 @@ def cmd_eval(context):
     if not os.path.isdir(path_results):
         os.makedirs(path_results)
 
+    df_results = pd.DataFrame()
     path_pred = os.path.join(context['log_directory'], 'pred_masks')
     for fname_pred in os.listdir(path_pred):
-        subj_acq = fname_pred.split('_')[0]
-        fname_gt = fname_pred.split('_pred.nii.gz')[0]+context['target_suffix']+'.nii.gz'
+        subj_acq = fname_pred.split('_pred.nii.gz')[0]
+        fname_gt = subj_acq+context['target_suffix']+'.nii.gz'
+        subj, acq = subj_acq.split('_')[0], '_'.join(subj_acq.split('_')[1:])
+
+        fname_pred = os.path.join(path_pred, fname_pred)
+        fname_gt = os.path.join(context['bids_path'], 'derivatives', 'labels', subj, 'anat', fname_gt)
+
+        eval = Evaluation3DMetrics(fname_pred=fname_pred, fname_gt=fname_gt)
+        df_results = df_results.append(eval.get_all_metrics(), ignore_index=True)
+        print(df_results.head())
 
 def run_main():
     if len(sys.argv) <= 1:

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -770,7 +770,6 @@ def cmd_eval(context):
         df_results = df_results.append(results_pred, ignore_index=True)
 
     df_results = df_results.set_index('image_id')
-    print(df_results.head())
 
     # save results as csv
     fname_out = os.path.join(path_results, 'evaluation_3Dmetrics.csv')

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -760,7 +760,10 @@ def cmd_eval(context):
 
         results_pred['image_id'] = subj_acq
         df_results = df_results.append(results_pred, ignore_index=True)
-        print(df_results.head())
+
+    fname_out = os.path.join(path_results, 'evaluation_3Dmetrics.csv')
+    df_results.to_csv(fname_out)
+
 
 def run_main():
     if len(sys.argv) <= 1:

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -734,6 +734,21 @@ def cmd_eval(context):
     print("Working on {}.".format(device))
 
 
+    if context.get("split_path") is None:
+        test_lst = joblib.load("./" + context["log_directory"] + "/split_datasets.joblib")['test']
+    else:
+        test_lst = joblib.load(context["split_path"])['test']
+
+    # create output folder for results
+    path_results = os.path.join(context['log_directory'], 'results_eval')
+    if not os.path.isdir(path_results):
+        os.makedirs(path_results)
+
+    path_pred = os.path.join(context['log_directory'], 'pred_masks')
+    for fname_pred in os.listdir(path_pred):
+        subj_acq = fname_pred.split('_')[0]
+        fname_gt = fname_pred.split('_pred.nii.gz')[0]+context['target_suffix']+'.nii.gz'
+
 def run_main():
     if len(sys.argv) <= 1:
         print("\nivadomed [config.json]\n")

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -49,6 +49,8 @@ class Evaluation3DMetrics(object):
 
         self.px, self.py, self.pz = self.get_pixdim(self.fname_pred)
 
+        # Note: Some papers suggested to remove all lesion with less than 3 voxels: Todo?
+
         # 18-connected components
         self.data_pred_label, self.n_pred = label(self.data_pred,
                                                     connectivity=3,

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -78,43 +78,15 @@ class Evaluation3DMetrics(object):
         """Absolute volume difference."""
         return abs(self.get_rvd())
 
-    def get_dice(self):
-        return dice_score(self.data_gt, self.data_pred) * 100.
-
-    def get_precision(self):
-        """Positive predictive values, precision."""
-        FP, FN, TP, TN = mt_metrics.numeric_score(self.data_pred, self.data_gt)
-        if (TP + FP) <= 0.0:
-            return np.nan
-
-        precision = np.divide(TP, TP + FP)
-        return precision * 100.0
-
-    def get_recall(self):
-        """Recal, TPR, sensitivity."""
-        FP, FN, TP, TN = mt_metrics.numeric_score(self.data_pred, self.data_gt)
-        if (TP + FN) <= 0.0:
-            return np.nan
-
-        TPR = np.divide(TP, TP + FN)
-        return TPR * 100.0
-
-    def get_specificity(self):
-        """Specificity, TNR."""
-        FP, FN, TP, TN = mt_metrics.numeric_score(self.data_pred, self.data_gt)
-        if (TN + FP) <= 0.0:
-            return 0.0
-        TNR = np.divide(TN, TN + FP)
-        return TNR * 100.0
-
     def get_all_metrics(self):
         dct = {}
         dct['vol_pred'] = self.get_vol(self.data_pred)
         dct['vol_gt'] = self.get_vol(self.data_gt)
         dct['rvd'], dct['avd'] = self.get_rvd(), self.get_avd()
-        dct['dice'] = self.get_dice()
-        dct['recall'], dct['precision'] = self.get_recall(), self.get_precision()
-        dct['specificity'] = self.get_specificity()
+        dct['dice'] = dice_score(self.data_gt, self.data_pred) * 100.
+        dct['recall'] = mt_metrics.recall_score(self.data_pred, self.data_gt, err_value=np.nan)
+        dct['precision'] = mt_metrics.precision_score(self.data_pred, self.data_gt, err_value=np.nan)
+        dct['specificity'] = mt_metrics.specificity_score(self.data_pred, self.data_gt, err_value=np.nan)
 
         return dct
 

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -34,6 +34,48 @@ class IvadoMetricManager(mt_metrics.MetricManager):
         return res_dict
 
 
+class Evaluation3DMetrics(object):
+
+    def __init__(self, fname_pred, fname_gt, params=None):
+        self.fname_pred = fname_pred
+        self.fname_gt = fname_gt
+
+        if not params is None:
+            pass
+
+        self.data_pred = self.get_data(self.fname_pred)
+        self.data_gt = self.get_data(self.fname_gt)
+
+        self.px, self.py, self.pz = self.get_pixdim()
+
+    def get_data(self, fname):
+        nib_im = nib.load(fname)
+        return nib_im.get_data()
+
+    def get_pixdim(self, fname=self.fname_pred)
+        nib_im = nib.load(fname)
+        px, py, pz = nib_im.header['pixdim'][1:4]
+        return px, py, pz
+
+    def get_vol(self, data):
+        vol = np.sum(data)
+        vol *= self.px * self.py * self.pz
+        return vol
+
+    def get_rvd(self):
+        """Relative volume difference."""
+        vol_gt = self.get_vol(self.data_gt)
+        vol_pred = self.get_vol(self.data_pred)
+
+        avd = vol_gt-vol_pred
+        avd /= vol_gt
+        return avd
+
+    def get_avd(self):
+        """Absolute volume difference."""
+        return abs(self.get_rvd())
+
+
 def save_nii(data_lst, z_lst, fname_ref, fname_out, slice_axis, debug=False):
     """Save the prediction as nii.
         1. Reconstruct a 3D volume out of the slice-wise predictions.

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -2,6 +2,7 @@ import torch
 import numpy as np
 import nibabel as nib
 from PIL import Image
+from skimage.measure import label
 import torchvision.transforms.functional as F
 import matplotlib.pyplot as plt
 from collections import defaultdict
@@ -47,6 +48,14 @@ class Evaluation3DMetrics(object):
         self.data_gt = self.get_data(self.fname_gt)
 
         self.px, self.py, self.pz = self.get_pixdim(self.fname_pred)
+
+        # 18-connected components
+        self.data_pred_label, self.n_pred = label(self.data_pred,
+                                                    connectivity=3,
+                                                    return_num=True)
+        self.data_gt_label, self.n_gt = label(self.data_gt,
+                                                connectivity=3,
+                                                return_num=True)
 
     def get_data(self, fname):
         nib_im = nib.load(fname)

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -114,28 +114,35 @@ class Evaluation3DMetrics(object):
         for idx in range(1, self.n_pred+1):
             data_pred_idx = (self.data_pred_label == idx).astype(np.int)
             overlap = (data_pred_idx * self.data_gt).astype(np.int)
+
             if np.count_nonzero(overlap) < overlap_vox:
                 lfp += 1
 
         return lfp
 
     def get_ltpr(self):
-        """Lesion True Positive Rate / Recall / Sensitivity."""
+        """Lesion True Positive Rate / Recall / Sensitivity.
+
+            Note: computed only if self.n_gt >= 1.
+        """
         ltp, lfn = self._get_ltp_lfn()
 
         denom = ltp + lfn
-        if denom == 0:
+        if denom == 0 or self.n_gt == 0:
             return np.nan
 
         return ltp * 100. / denom
 
     def get_lfdr(self):
-        """Lesion False Detection Rate / 1 - Precision."""
+        """Lesion False Detection Rate / 1 - Precision.
+
+            Note: computed only if self.n_gt >= 1.
+        """
         ltp, _ = self._get_ltp_lfn()
         lfp = self._get_lfp()
 
         denom = ltp + lfp
-        if denom == 0:
+        if denom == 0 or self.n_gt == 0:
             return np.nan
 
         return lfp * 100. / denom

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -66,7 +66,10 @@ class Evaluation3DMetrics(object):
         """Relative volume difference."""
         vol_gt = self.get_vol(self.data_gt)
         vol_pred = self.get_vol(self.data_pred)
-        print(vol_gt, vol_pred)
+
+        if vol_gt == 0.0:
+            return np.nan
+
         rvd = (vol_gt-vol_pred)*100.
         rvd /= vol_gt
         return rvd
@@ -103,6 +106,17 @@ class Evaluation3DMetrics(object):
             return 0.0
         TNR = np.divide(TN, TN + FP)
         return TNR * 100.0
+
+    def get_all_metrics(self):
+        dct = {}
+        dct['vol_pred'] = self.get_vol(self.data_pred)
+        dct['vol_gt'] = self.get_vol(self.data_gt)
+        dct['rvd'], dct['avd'] = self.get_rvd(), self.get_avd()
+        dct['dice'] = self.get_dice()
+        dct['recall'], dct['precision'] = self.get_recall(), self.get_precision()
+        dct['specificity'] = self.get_specificity()
+
+        return dct
 
 
 def save_nii(data_lst, z_lst, fname_ref, fname_out, slice_axis, debug=False):

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -149,6 +149,9 @@ class Evaluation3DMetrics(object):
         dct['recall'] = mt_metrics.recall_score(self.data_pred, self.data_gt, err_value=np.nan)
         dct['precision'] = mt_metrics.precision_score(self.data_pred, self.data_gt, err_value=np.nan)
         dct['specificity'] = mt_metrics.specificity_score(self.data_pred, self.data_gt, err_value=np.nan)
+        dct['n_pred'], dct['n_gt'] = self.n_pred, self.n_gt
+        dct['ltpr'] = self.get_ltpr()
+        dct['lfdr'] = self.get_lfdr()
 
         return dct
 


### PR DESCRIPTION
Evaluation on the testing dataset is currently performed on a slice-wise basis, the average value of the metrics is displayed in the terminal.

Overall, this PR aims at computing the evaluation metrics per 3D data, saving the results for each image, which opens the door to a finer analyses of the results, eg across center? across tumour type? while being more meaningful in practice than slice-wise approach.

### Implementation
1. `class Evaluation3DMetrics` in `ivadomed/utils.py` which compute the different metrics from `fname_pred` and `fname_gt`. Possible to request only one metric at a time (e.g. `self.get_dice()`) or all at the same time via `self.get_all_metrics()` which output a dictionary.
2. `config` --> You can now specify `eval` for the `command` parameter.
3. `cmd_eval(context)` in `ivadomed/main.py`.

### How to run
1. Modify the `config` file with `eval` for the `command` parameter.
2. Run `ivadomed [config.json]`
```
Working on cpu.
Evaluation: 100%|████████████████████████████████████████████████████████████████████████████████████████████| 266/266 [01:02<00:00,  4.27it/s]
```
3. Grab your results in: `log_directory/results_eval/evaluation_3Dmetrics.csv`, which look like something like this (ignore the poor results, obtained with model trained with 2 epochs, charlie impatient):
```
                                                avd      dice  precision      recall         rvd  specificity       vol_gt     vol_pred
image_id                                                                                                                               
sub-nyuShepherd102_acq-sag_T2w                  NaN  0.000000   0.000000         NaN         NaN    99.970678     0.000000   711.187899
sub-milanFilippi063_acq-sag_T2w                 NaN  0.000000   0.000000         NaN         NaN    99.968749     0.000000   646.016861
sub-montpellierLesion012_acq-sup_T2star  162.336585  0.118762  44.067797  100.000000 -162.336585    99.997392    44.049699   115.558475
sub-nihReich013_T2star                    79.286144  1.320280  44.910645   92.038217  -79.286144    99.982746  1273.158445  2282.596680
sub-bwh041_acq-sagstir_T2w                      NaN  0.000000   0.000000         NaN         NaN    99.989306     0.000000   265.386313
```
Note: the `NaN` occurs when division by zero or empty GT or...etc. see `class Evaluation3DMetrics` for further details.

### Metrics:
All metrics are in percentage, except the last ones.
For all metrics in percentage, the best value is `100.` while it is `0.` for `avd`, `rvd` and `lfdr`.
- Dice score, of course
- Relative Volume Difference (`rvd`), Absolute Volume Difference (`avd`)
- Voxel-wise recall, precision, specificity.
- Structure-wise True Postive Rate (`ltpr`) and False Detection Rate (`lfdr`).
- Volume GT (`vol_gt`) and prediction (`vol_pred`), in mm3.
- Number of lesions (`n_gt` and `n_pred`).

Besides the opportunity to feed tables of results, this csv file could be used to generate violin plots (e.g. `seaborn`), or correlation plots `vol_gt` vs. `vol_pred` such as:
![Screenshot 2019-12-18 17:21:46](https://user-images.githubusercontent.com/14353425/71060914-eb16e000-21ba-11ea-8480-f0011458e8fb.png)

Fixes #45 
