### PR TITLE
Remove macos from github actions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,10 +7,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         python-version: [3.6, 3.7]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
 
 
     steps:


### PR DESCRIPTION
Already covered by travis and tends to fail (timeout) due to the fact that it's slower than linux