### PR TITLE
Rotation undo transform for Aleatoric uncertainty

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -74,5 +74,17 @@
 		"ToTensor": {},
 		"NormalizeInstance": {}
 		},
+        "transformation_testing": {
+                "Resample": {
+                        "wspace": 0.75,
+                        "hspace": 0.75
+                        },
+                "CenterCrop2D": {
+                        "size": [128, 128]
+                        },
+                "ToTensor": {},
+                "NormalizeInstance": {}
+                },
+
         "debugging": true
 }

--- a/config/config_gm.json
+++ b/config/config_gm.json
@@ -71,5 +71,16 @@
 		"ToTensor": {},
 		"NormalizeInstance": {}
 		},
+        "transformation_testing": {
+                "Resample": {
+                        "wspace": 0.75,
+                        "hspace": 0.75
+                        },
+                "CenterCrop2D": {
+                        "size": [128, 128]
+                        },
+                "ToTensor": {},
+                "NormalizeInstance": {}
+                },
 	"debugging": false
 }

--- a/config/config_sctTesting.json
+++ b/config/config_sctTesting.json
@@ -72,5 +72,16 @@
 		"ToTensor": {},
 		"NormalizeInstance": {}
 		},
+        "transformation_testing": {
+                "Resample": {
+                        "wspace": 0.75,
+                        "hspace": 0.75
+                        },
+                "ROICrop2D": {
+                        "size": [48, 48]
+                        },
+                "ToTensor": {},
+                "NormalizeInstance": {}
+                },
         "debugging": false
 }

--- a/config/config_sctTesting_lesionAx.json
+++ b/config/config_sctTesting_lesionAx.json
@@ -33,9 +33,9 @@
         "balance_samples": false,
 	"slice_filter": {"filter_empty_mask": false, "filter_empty_input": true},
         "slice_filter_roi": 10,
-	"uncertainty": {"epistemic": true, "aleatoric": true, "n_it": 10},
+	"uncertainty": {"epistemic": true, "aleatoric": false, "n_it": 10},
 	"unet_3D": false,
-	"binarize_prediction": true,
+	"binarize_prediction": false,
 	"early_stopping_patience": 20,
 	"early_stopping_epsilon": 0.1,
 	"transformation_training": {
@@ -82,7 +82,7 @@
                         "size": [48, 48]
                         },
                 "RandomRotation": {
-                        "degrees": 45
+                        "degrees": 30
                         },
                 "ToTensor": {},
                 "NormalizeInstance": {}

--- a/config/config_sctTesting_lesionAx.json
+++ b/config/config_sctTesting_lesionAx.json
@@ -70,6 +70,9 @@
 		"ROICrop2D": {
 			"size": [48, 48]
 			},
+                "RandomRotation": {
+                        "degrees": 4.6
+                        },
 		"ToTensor": {},
 		"NormalizeInstance": {}
 		},

--- a/config/config_sctTesting_lesionAx.json
+++ b/config/config_sctTesting_lesionAx.json
@@ -33,7 +33,7 @@
         "balance_samples": false,
 	"slice_filter": {"filter_empty_mask": false, "filter_empty_input": true},
         "slice_filter_roi": 10,
-	"uncertainty": {"epistemic": true, "aleatoric": false, "n_it": 10},
+	"uncertainty": {"epistemic": true, "aleatoric": true, "n_it": 10},
 	"unet_3D": false,
 	"binarize_prediction": true,
 	"early_stopping_patience": 20,
@@ -70,11 +70,22 @@
 		"ROICrop2D": {
 			"size": [48, 48]
 			},
-                "RandomRotation": {
-                        "degrees": 4.6
-                        },
 		"ToTensor": {},
 		"NormalizeInstance": {}
 		},
+        "transformation_testing": {
+                "Resample": {
+                        "wspace": 0.75,
+                        "hspace": 0.75
+                        },
+                "ROICrop2D": {
+                        "size": [48, 48]
+                        },
+                "RandomRotation": {
+                        "degrees": 45
+                        },
+                "ToTensor": {},
+                "NormalizeInstance": {}
+                },
         "debugging": false
 }

--- a/config/config_small.json
+++ b/config/config_small.json
@@ -73,5 +73,16 @@
 		"ToTensor": {},
 		"NormalizeInstance": {}
 		},
+        "transformation_testing": {
+                "Resample": {
+                        "wspace": 0.75,
+                        "hspace": 0.75
+                        },
+                "CenterCrop2D": {
+                        "size": [128, 128]
+                        },
+                "ToTensor": {},
+                "NormalizeInstance": {}
+                },
 	"debugging": false
 }

--- a/config/config_tumorSeg.json
+++ b/config/config_tumorSeg.json
@@ -63,5 +63,10 @@
       "NormalizeInstance3D": {},
       "StackTensors": {}
     },
+    "transformation_testing": {
+      "ToTensor3D": {},
+      "NormalizeInstance3D": {},
+      "StackTensors": {}
+    },
     "debugging": false
 }

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -637,6 +637,7 @@ def cmd_test(context):
 
     # These are the validation/testing transformations
     validation_transform_list = []
+    print('\nApplied transformations:')
     for transform in context["transformation_testing"].keys():
         parameters = context["transformation_testing"][transform]
         if transform in ivadomed_transforms.get_transform_names():
@@ -645,9 +646,10 @@ def cmd_test(context):
             transform_obj = getattr(mt_transforms, transform)(**parameters)
         # check if undo_transform method is implemented
         if hasattr(transform_obj, 'undo_transform'):
+            print('\t- {}'.format(transform))
             validation_transform_list.append(transform_obj)
         else:
-            print('\n{} has no undo_transform implemented, not applicable during inference'.format(transform))
+            print('\t- {} NOT included (no undo_transform implemented)'.format(transform))
 
     val_transform = transforms.Compose(validation_transform_list)
 
@@ -851,7 +853,7 @@ def cmd_test(context):
 
 def cmd_eval(context):
     ##### DEFINE DEVICE #####
-    cmd_test(context)
+#    cmd_test(context)
     device = torch.device("cpu")
     print("Working on {}.".format(device))
 

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -656,6 +656,7 @@ def cmd_test(context):
             validation_transform_list.append(transform_obj)
         else:
             print('\t- {} NOT included (no undo_transform implemented)'.format(transform))
+    print('\n')
 
     val_transform = transforms.Compose(validation_transform_list)
 
@@ -716,7 +717,7 @@ def cmd_test(context):
     metric_mgr = IvadoMetricManager(metric_fns)
 
     # number of Monte Carlo simulation
-    if (context['uncertainty']['epistemic'] or context['uncertainty']['epistemic']) and context['uncertainty']['n_it'] > 0:
+    if (context['uncertainty']['epistemic'] or context['uncertainty']['aleatoric']) and context['uncertainty']['n_it'] > 0:
         n_monteCarlo = context['uncertainty']['n_it']
     else:
         n_monteCarlo = 1

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -638,13 +638,13 @@ def cmd_test(context):
     # These are the validation/testing transformations
     validation_transform_list = []
     for transform in context["transformation_testing"].keys():
-        parameters = transformation_dict[transform]
+        parameters = context["transformation_testing"][transform]
         if transform in ivadomed_transforms.get_transform_names():
             transform_obj = getattr(ivadomed_transforms, transform)(**parameters)
         else:
             transform_obj = getattr(mt_transforms, transform)(**parameters)
         # check if undo_transform method is implemented
-        if hasattr(connection, 'undo_transform'):
+        if hasattr(transform_obj, 'undo_transform'):
             validation_transform_list.append(transform_obj)
         else:
             print('\n{} has no undo_transform implemented, not applicable during inference'.format(transform))
@@ -776,8 +776,8 @@ def cmd_test(context):
                             fname_pred = fname_pred.split(
                                 '.nii.gz')[0]+'_'+str(i_monteCarlo).zfill(2)+'.nii.gz'
 
-                        save_nii(pred_tmp_lst, z_tmp_lst, fname_tmp, fname_pred, AXIS_DCT[context['slice_axis']],
-                                 context["binarize_prediction"])
+                        save_nii(pred_tmp_lst, z_tmp_lst, fname_tmp, fname_pred, slice_axis=AXIS_DCT[context['slice_axis']],
+                                 binarize=context["binarize_prediction"])
 
                         # re-init pred_stack_lst
                         pred_tmp_lst, z_tmp_lst = [], []
@@ -793,7 +793,7 @@ def cmd_test(context):
                     fname_pred = fname_pred.split(context['target_suffix'])[0] + '_pred.nii.gz'
                     # Choose only one modality
                     save_nii(rdict_undo['gt'][0, :, :, :].transpose((1, 2, 0)), [], fname_ref, fname_pred,
-                             AXIS_DCT[context['slice_axis']], unet_3D=True)
+                             slice_axis=AXIS_DCT[context['slice_axis']], unet_3D=True)
 
         # Metrics computation
         gt_npy = gt_samples.numpy().astype(np.uint8)

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -635,19 +635,19 @@ def cmd_test(context):
     else:
         print('\tInclude all subjects, with or without acquisition metadata.\n')
 
-    # Aleatoric uncertainty
-    if context['uncertainty']['aleatoric'] and context['uncertainty']['n_it'] > 0:
-        transformation_dict = context["transformation_training"]
-    else:
-        transformation_dict = context["transformation_validation"]
     # These are the validation/testing transformations
     validation_transform_list = []
-    for transform in transformation_dict.keys():
+    for transform in context["transformation_testing"].keys():
         parameters = transformation_dict[transform]
         if transform in ivadomed_transforms.get_transform_names():
-            validation_transform_list.append(getattr(ivadomed_transforms, transform)(**parameters))
+            transform_obj = getattr(ivadomed_transforms, transform)(**parameters)
         else:
-            validation_transform_list.append(getattr(mt_transforms, transform)(**parameters))
+            transform_obj = getattr(mt_transforms, transform)(**parameters)
+        # check if undo_transform method is implemented
+        if hasattr(connection, 'undo_transform'):
+            validation_transform_list.append(transform_obj)
+        else:
+            print('\n{} has no undo_transform implemented, not applicable during inference'.format(transform))
 
     val_transform = transforms.Compose(validation_transform_list)
 

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -685,9 +685,9 @@ def cmd_test(context):
         one_hot_encoder = joblib.load("./" + context["log_directory"] + "/one_hot_encoder.joblib")
 
     if not context["unet_3D"]:
-        print(f"Loaded {len(ds_test)} {context['slice_axis']} slices for the test set.")
+        print(f"\nLoaded {len(ds_test)} {context['slice_axis']} slices for the test set.")
     else:
-        print(f"Loaded {len(ds_test)} volumes of size {context['length_3D']} for the test set.")
+        print(f"\nLoaded {len(ds_test)} volumes of size {context['length_3D']} for the test set.")
 
     test_loader = DataLoader(ds_test, batch_size=context["batch_size"],
                              shuffle=False, pin_memory=True,

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -668,7 +668,7 @@ def cmd_test(context):
     else:
         test_lst = joblib.load(context["split_path"])['test']
 
-    ds_test = loader.load_dataset(test_lst, val_transform, context)
+    ds_test = loader.load_dataset(test_lst[:20], val_transform, context)
 
     # if ROICrop2D in transform, then apply SliceFilter to ROI slices
     if 'ROICrop2D' in context["transformation_validation"].keys():
@@ -722,11 +722,12 @@ def cmd_test(context):
     else:
         n_monteCarlo = 1
 
-    pred_tmp_lst, z_tmp_lst, fname_tmp = [], [], ''
-    for i, batch in enumerate(test_loader):
-        input_samples, gt_samples = batch["input"], batch["gt"]
+    for i_monteCarlo in range(n_monteCarlo):
+        pred_tmp_lst, z_tmp_lst, fname_tmp = [], [], ''
+        for i, batch in enumerate(test_loader):
+            input_samples, gt_samples = batch["input"], batch["gt"]
 
-        for i_monteCarlo in range(n_monteCarlo):
+    #    for i_monteCarlo in range(n_monteCarlo):
             with torch.no_grad():
                 if cuda_available:
                     test_input = cuda(input_samples)
@@ -786,13 +787,13 @@ def cmd_test(context):
                                 '.nii.gz')[0]+'_'+str(i_monteCarlo).zfill(2)+'.nii.gz'
 
                         save_nii(pred_tmp_lst, z_tmp_lst, fname_tmp, fname_pred, slice_axis=AXIS_DCT[context['slice_axis']],
-                                 binarize=context["binarize_prediction"])
+                                 binarize=False)  #context["binarize_prediction"])
 
                         # re-init pred_stack_lst
                         pred_tmp_lst, z_tmp_lst = [], []
 
                     # add new sample to pred_tmp_lst
-                    pred_tmp_lst.append(np.array(rdict_undo['gt']))
+                    pred_tmp_lst.append(np.array(rdict_undo['input']))
                     z_tmp_lst.append(int(rdict_undo['input_metadata']['slice_index']))
                     fname_tmp = fname_ref
 

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -635,11 +635,17 @@ def cmd_test(context):
     else:
         print('\tInclude all subjects, with or without acquisition metadata.\n')
 
+    # Aleatoric uncertainty
+    if context['uncertainty']['aleatoric'] and context['uncertainty']['n_it'] > 0:
+        transformation_dict = context["transformation_testing"]
+    else:
+        transformation_dict = context["transformation_validation"]
+
     # These are the validation/testing transformations
     validation_transform_list = []
     print('\nApplied transformations:')
-    for transform in context["transformation_testing"].keys():
-        parameters = context["transformation_testing"][transform]
+    for transform in transformation_dict.keys():
+        parameters = transformation_dict[transform]
         if transform in ivadomed_transforms.get_transform_names():
             transform_obj = getattr(ivadomed_transforms, transform)(**parameters)
         else:
@@ -852,8 +858,13 @@ def cmd_test(context):
 
 
 def cmd_eval(context):
+    path_pred = os.path.join(context['log_directory'], 'pred_masks')
+    if not os.path.isdir(path_pred):
+        print('\nRun Inference\n')
+        cmd_test(context)
+    print('\nRun Evaluation on {}\n'.format(path_pred))
+
     ##### DEFINE DEVICE #####
-#    cmd_test(context)
     device = torch.device("cpu")
     print("Working on {}.".format(device))
 
@@ -866,7 +877,6 @@ def cmd_eval(context):
     df_results = pd.DataFrame()
 
     # list subject_acquisition
-    path_pred = os.path.join(context['log_directory'], 'pred_masks')
     subj_acq_lst = [f.split('_pred')[0]
                     for f in os.listdir(path_pred) if f.endswith('_pred.nii.gz')]
 

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -86,6 +86,7 @@ class Evaluation3DMetrics(object):
 
         rvd = (vol_gt-vol_pred)*100.
         rvd /= vol_gt
+
         return rvd
 
     def get_avd(self):

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -253,21 +253,19 @@ def run_uncertainty(ifolder):
 
         # if final segmentation from Monte Carlo simulations has not been generated yet
         if not os.path.isfile(fname_pred) or not os.path.isfile(fname_soft):
-            # find Monte Carlo simulations
-            fname_pred_lst = [os.path.join(ifolder, f)
-                              for f in os.listdir(ifolder) if subj_acq+'_pred_' in f]
-
             # threshold used for the hard segmentation
             thr = 1. / len(fname_pred_lst)  # 1 for all voxels where at least on MC sample predicted 1
+            print(thr)
             # average then argmax
             combine_predictions(fname_pred_lst, fname_pred, fname_soft, thr=thr)
 
         fname_unc_vox = os.path.join(ifolder, subj_acq+'_unc-vox.nii.gz')
-        fname_unc_struct = os.path.join(ifolder, subj_acq+'_unc.nii.gz')
-        if not os.path.isfile(fname_unc_vox) or not os.path.isfile(fname_unc_struct):
+        if not os.path.isfile(fname_unc_vox):
             # compute voxel-wise uncertainty map
             voxelWise_uncertainty(fname_pred_lst, fname_unc_vox)
 
+        fname_unc_struct = os.path.join(ifolder, subj_acq+'_unc.nii.gz')
+        if not os.path.isfile(os.path.join(ifolder, subj_acq+'_unc-cv.nii.gz')):
             # compute structure-wise uncertainty
             structureWise_uncertainty(fname_pred_lst, fname_pred, fname_unc_vox, fname_unc_struct)
 

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -255,7 +255,6 @@ def run_uncertainty(ifolder):
         if not os.path.isfile(fname_pred) or not os.path.isfile(fname_soft):
             # threshold used for the hard segmentation
             thr = 1. / len(fname_pred_lst)  # 1 for all voxels where at least on MC sample predicted 1
-            print(thr)
             # average then argmax
             combine_predictions(fname_pred_lst, fname_pred, fname_soft, thr=thr)
 
@@ -285,14 +284,13 @@ def combine_predictions(fname_lst, fname_hard, fname_prob, thr=0.5):
 
     # average over all the MC simulations
     data_prob = np.mean(np.array(data_lst), axis=0)
-    # argmax operator
-    # TODO: adapt for multi-label pred
-    data_hard = threshold_predictions(data_prob, thr=thr).astype(np.uint8)
-
     # save prob segmentation
     nib_prob = nib.Nifti1Image(data_prob, nib_im.affine)
     nib.save(nib_prob, fname_prob)
 
+    # argmax operator
+    # TODO: adapt for multi-label pred
+    data_hard = threshold_predictions(data_prob, thr=thr).astype(np.uint8)
     # save hard segmentation
     nib_hard = nib.Nifti1Image(data_hard, nib_im.affine)
     nib.save(nib_hard, fname_hard)

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -257,8 +257,10 @@ def run_uncertainty(ifolder):
             fname_pred_lst = [os.path.join(ifolder, f)
                               for f in os.listdir(ifolder) if subj_acq+'_pred_' in f]
 
+            # threshold used for the hard segmentation
+            thr = 1. / len(fname_pred_lst)  # 1 for all voxels where at least on MC sample predicted 1
             # average then argmax
-            combine_predictions(fname_pred_lst, fname_pred, fname_soft)
+            combine_predictions(fname_pred_lst, fname_pred, fname_soft, thr=thr)
 
         fname_unc_vox = os.path.join(ifolder, subj_acq+'_unc-vox.nii.gz')
         fname_unc_struct = os.path.join(ifolder, subj_acq+'_unc.nii.gz')
@@ -270,7 +272,7 @@ def run_uncertainty(ifolder):
             structureWise_uncertainty(fname_pred_lst, fname_pred, fname_unc_vox, fname_unc_struct)
 
 
-def combine_predictions(fname_lst, fname_hard, fname_prob, thr):
+def combine_predictions(fname_lst, fname_hard, fname_prob, thr=0.5):
     """
     Combine predictions from Monte Carlo simulations
     by applying:

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import numpy as np
 import nibabel as nib

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -1,5 +1,6 @@
 import os
 import torch
+from tqdm import tqdm
 import numpy as np
 import nibabel as nib
 from PIL import Image
@@ -269,7 +270,7 @@ def run_uncertainty(ifolder):
             structureWise_uncertainty(fname_pred_lst, fname_pred, fname_unc_vox, fname_unc_struct)
 
 
-def combine_predictions(fname_lst, fname_hard, fname_prob):
+def combine_predictions(fname_lst, fname_hard, fname_prob, thr):
     """
     Combine predictions from Monte Carlo simulations
     by applying:
@@ -278,7 +279,6 @@ def combine_predictions(fname_lst, fname_hard, fname_prob):
     """
     # collect all MC simulations
     data_lst = []
-    print(fname_lst)
     for fname in fname_lst:
         nib_im = nib.load(fname)
         data_lst.append(nib_im.get_fdata())
@@ -287,7 +287,7 @@ def combine_predictions(fname_lst, fname_hard, fname_prob):
     data_prob = np.mean(np.array(data_lst), axis=0)
     # argmax operator
     # TODO: adapt for multi-label pred
-    data_hard = np.round(data_prob).astype(np.uint8)
+    data_hard = threshold_predictions(data_prob, thr=thr).astype(np.uint8)
 
     # save prob segmentation
     nib_prob = nib.Nifti1Image(data_prob, nib_im.affine)

--- a/testing/test_undoTrans.py
+++ b/testing/test_undoTrans.py
@@ -38,20 +38,23 @@ def test_undo(contrast='T2star', tol=3):
     test_1 = [ivadomed_transforms.ToTensor(), ivadomed_transforms.NormalizeInstance()]
     name_1 = 'ToTensor_NoramlizeInstance'
 
-    test_2 = [mt_transforms.CenterCrop2D(size=[40, 48])] + test_1
-    name_2 = 'CenterCrop2D_' + name_1
+    test_2 = [mt_transforms.RandomRotation(degrees=10)] + test_1
+    name_2 = 'RandomRotation_' + name_1
 
-    test_3 = [ivadomed_transforms.ROICrop2D(size=[40, 48])] + test_1
-    name_3 = 'ROICrop2D_' + name_1
+    test_3 = [mt_transforms.CenterCrop2D(size=[40, 48])] + test_2
+    name_3 = 'CenterCrop2D_' + name_2
 
-    test_4 = [ivadomed_transforms.Resample(wspace=0.75, hspace=0.75)] + test_2
-    name_4 = 'Resample_' + name_2
+    test_4 = [ivadomed_transforms.ROICrop2D(size=[40, 48])] + test_2
+    name_4 = 'ROICrop2D_' + name_2
 
     test_5 = [ivadomed_transforms.Resample(wspace=0.75, hspace=0.75)] + test_3
     name_5 = 'Resample_' + name_3
 
-    name_lst = [name_2, name_3, name_4, name_5]
-    test_lst = [test_2, test_3, test_4, test_5]
+    test_6 = [ivadomed_transforms.Resample(wspace=0.75, hspace=0.75)] + test_4
+    name_6 = 'Resample_' + name_4
+
+    name_lst = [name_2, name_3, name_4, name_5, name_6]
+    test_lst = [test_2, test_3, test_4, test_5, test_6]
 
     subject_test_lst = ['sub-test001']
 


### PR DESCRIPTION
We need to implement Rotation undo transform for Aleatoric uncertainty purposes. See issue #136 

Sister PR: https://github.com/neuropoly/medicaltorch/pull/16

To test this PR:
1. Run:
```
python testing/test_undoTrans.py
```
2. Use `cmd_test` with:
- `uncertainty: {aleatoric: true}`.
- in `transformation_training`: `RandomRotation: {degrees: XX}`

Fix #136