### PR TITLE
Fix errors in prepare_data.sh

### DIFF
--- a/prepare_data/prepare_data.sh
+++ b/prepare_data/prepare_data.sh
@@ -47,6 +47,7 @@ segment_if_does_not_exist(){
   if [ -e "${PATH_SEGMANUAL}/${file}_seg-manual.nii.gz" ]; then
     echo "Found manual segmentation: ${PATH_SEGMANUAL}/${FILESEG}-manual.nii.gz"
     cp "${PATH_SEGMANUAL}/${FILESEG}-manual.nii.gz" ${FILESEG}.nii.gz
+    sct_register_multimodal -i ${FILESEG}.nii.gz -d ${file}.nii.gz -identity 1 -o ${FILESEG}.nii.gz 
     sct_qc -i ${file}.nii.gz -s ${FILESEG}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
   else
     # Segment spinal cord
@@ -69,7 +70,7 @@ cp ${PATH_IN}/${file_t2s}.nii.gz .
 cp ${PATH_IN}/${file_t1w}.nii.gz .
 
 # Crop to avoid imperfect slab profile at the edge (altered contrast)
-sct_crop_image -i ${file_t1w_mts}.nii.gz -o ${file_t1w_mts}_crop.nii.gz -zmin 3 -zmax -3
+sct_crop_image -i ${file_t1w_mts}.nii.gz -o ${file_t1w_mts}_crop.nii.gz -zmin 3 -zmax -4
 file_t1w_mts="${file_t1w_mts}_crop"
 
 # Resample to fixed resolution


### PR DESCRIPTION
- Following the PR #143, there was still a problem  with the use of the parameter **zmax** in _sct_crop_image_. As we want to remove the 3 lastest slices we need to set **zmax** to -4.
- We also added a registration of the manual seg onto the image voxel space in case, for some reasons, the manual seg is not in the same space (e.g. this could happen if the cropping values change across versions of this pipeline)