### PR TITLE
Lesion filtering using uncertainty -- DEV V1

### DIFF
--- a/config/config_sctTesting_lesionAx.json
+++ b/config/config_sctTesting_lesionAx.json
@@ -1,5 +1,5 @@
 {
-    "command": "eval",
+    "command": "train",
     "gpu": 1,
     "target_suffix": "_lesion-manual",
     "roi_suffix": "_seg-manual",

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -249,7 +249,7 @@ def run_main(args):
 
     subj_acq_lst = list(set([f.split('_pred')[0] for f in os.listdir(pred_folder)
                     if f.endswith('.nii.gz') and '_pred' in f]))
-    subj_acq_lst = [subj_acq_lst[0]]
+    #subj_acq_lst = [subj_acq_lst[0]]
     print(subj_acq_lst)
     gt_folder = os.path.join(context['bids_path'], 'derivatives', 'labels')
 
@@ -270,7 +270,7 @@ def run_main(args):
                                         gt_folder=gt_folder,
                                         pred_folder=pred_folder,
                                         im_lst=subj_acq_lst,
-                                        target_suf=context["target_suffix"],
+                                        target_suf=context["target_suffix"][0],
                                         param_eval=context["eval_params"])
                 joblib.dump(res, res_ofname)
             else:
@@ -288,7 +288,7 @@ def run_main(args):
                             im_lst=subj_acq_lst,
                             thr_pred=thrPred,
                             gt_folder=gt_folder,
-                            target_suf=context["target_suffix"],
+                            target_suf=context["target_suffix"][0],
                             param_eval=context["eval_params"],
                             unc_name=sufUnc,
                             thr_unc=thrUnc)

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -219,6 +219,15 @@ def run_inference(im_lst, fname_pref, thr_pred, gt_folder, target_suf, param_eva
                                     dim_lst=nib_gt.header['pixdim'][1:4],
                                     params=param_eval)
 
+        results_pred, _ = eval.run_eval()
+
+        # save results of this fname_pred
+        results_pred['image_id'] = subj_acq
+        df_results = df_results.append(results_pred, ignore_index=True)
+
+    return df_results
+
+
 def run_main(args):
 
     with open(args.c, "r") as fhandle:

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -36,7 +36,7 @@ def auc_homemade(fpr, tpr, trapezoid=False):
     ft = list(zip(fpr, tpr))
     for p0, p1 in zip(ft[: -1], ft[1: ]):
         area += (p1[0] - p0[0]) * ((p1[1] + p0[1]) / 2 if trapezoid else p0[1])
-    return area
+    return -area
 
 def print_unc_stats(unc_name, pred_folder, im_lst):
     mins, p25s, p50s, p75s, maxs = [], [], [], [], []
@@ -100,7 +100,7 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
             if np.any(data_gt) and np.any(data_soft):
                 for i_unc, thr_unc in enumerate(thr_unc_lst):
                     # discard uncertain lesions from data_soft
-                    print(thr_unc)
+                    #print(thr_unc)
                     data_soft_thrUnc = deepcopy(data_soft)
                     data_soft_thrUnc[data_unc > thr_unc] = 0
                     #print(np.sum(data_soft), np.sum(data_soft_thrUnc))
@@ -122,7 +122,7 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
                             tpr, _ = eval.get_ltpr()
                             fdr = eval.get_lfdr()
 
-                        print(thr_pred, tpr, fdr)
+                        #print(thr_pred, tpr, fdr)
 
                         res_dct['tpr'][i_unc][i_pred].append(tpr / 100.)
                         res_dct['fdr'][i_unc][i_pred].append(fdr / 100.)
@@ -132,7 +132,7 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
 
 def print_retained_elt(thr_unc_lst, retained_elt_lst):
     print('Mean percentage of retained elt:')
-    for i, t in thr_unc_lst:
+    for i, t in enumerate(thr_unc_lst):
        print('\tUnc threshold: {} --> {}'.format(t, np.mean(retained_elt_lst[i])))
 
 
@@ -150,7 +150,7 @@ def plot_roc(thr_unc_lst, thr_pred_lst, res_dct, metric, fname_out):
         optimal_threshold = thr_pred_lst[optimal_idx]
         print('AUC: {}, Optimal Pred Thr: {}'.format(auc_, optimal_threshold))
 
-        plt.plot(fdr_vals, tpr_vals, label='Unc thr={0:0.2f} (area = {1:0.2f})'.format(thr_unc, auc_))
+        plt.scatter(fdr_vals, tpr_vals, label='Unc thr={0:0.2f} (area = {1:0.2f})'.format(thr_unc, auc_), s=22)
 
     plt.plot([0, 1], [0, 1], 'k--')
     plt.xlim([0.0, 1.0])

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -115,7 +115,7 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
         if os.path.isfile(fname_gt):
             nib_gt = nib.load(fname_gt)
             data_gt = nib_gt.get_data()
-
+            print(np.sum(data_gt))
             # soft prediction
             data_soft = np.mean(data_pred_lst, axis=0)
 
@@ -126,7 +126,7 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
                     data_soft_thrUnc[data_unc > thr_unc] = 0
                     cmpt = count_retained((data_soft > 0).astype(np.int), (data_soft_thrUnc > 0).astype(np.int), level)
                     res_dct['retained_elt'][i_unc].append(cmpt)
-
+                    print(thr_unc, cmpt)
                     for i_pred, thr_pred in enumerate(thr_pred_lst):
                         data_hard = threshold_predictions(deepcopy(data_soft_thrUnc), thr=thr_pred).astype(np.uint8)
 
@@ -141,7 +141,7 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
                         else:
                             tpr, _ = eval.get_ltpr()
                             fdr = eval.get_lfdr()
-
+                        print(thr_pred, np.count_nonzero(deepcopy(data_soft_thrUnc)), np.count_nonzero(data_hard), tpr, fdr)
                         res_dct['tpr'][i_unc][i_pred].append(tpr / 100.)
                         res_dct['fdr'][i_unc][i_pred].append(fdr / 100.)
 
@@ -249,7 +249,8 @@ def run_main(args):
 
     subj_acq_lst = list(set([f.split('_pred')[0] for f in os.listdir(pred_folder)
                     if f.endswith('.nii.gz') and '_pred' in f]))
-
+    subj_acq_lst = [subj_acq_lst[0]]
+    print(subj_acq_lst)
     gt_folder = os.path.join(context['bids_path'], 'derivatives', 'labels')
 
     if thrPred is None:
@@ -273,9 +274,8 @@ def run_main(args):
                                         param_eval=context["eval_params"])
                 joblib.dump(res, res_ofname)
             else:
-                joblib.load(res_ofname)
+                res = joblib.load(res_ofname)
 
-            """
             print_retained_elt(thr_unc_lst=config_dct['uncertainty_thr'], retained_elt_lst=res['retained_elt'])
 
             plot_roc(thr_unc_lst=config_dct['uncertainty_thr'],
@@ -283,7 +283,6 @@ def run_main(args):
                         res_dct=res,
                         metric=config_dct['uncertainty_measure'],
                         fname_out=os.path.join(ofolder, config_dct['uncertainty_measure']+'.png'))
-           """
     else:
         df = run_inference(pred_folder=pred_folder,
                             im_lst=subj_acq_lst,

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -1,0 +1,51 @@
+##############################################################
+#
+# TODO
+#
+##############################################################
+
+import os
+import json
+import argparse
+import numpy as np
+import nibabel as nib
+
+from ivadomed.main import cmd_test
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", help="Config file path.")
+    parser.add_argument("-ofolder", help="Output folder.")
+
+    return parser
+
+def run_main(args):
+
+    with open(args.c, "r") as fhandle:
+        context = json.load(fhandle)
+
+    ofolder = args.ofolder
+    if not os.path.isdir(ofolder):
+        os.makedirs(ofolder)
+
+    pred_folder = os.path.join(context['log_directory'], 'pred_masks')
+    if not os.path.isdir(pred_folder):
+        cmd_test(context)
+
+    subj_acq_lst = list(set([f.split('_pred')[0] for f in os.listdir(pred_folder)
+                    if f.endswith('.nii.gz') and '_pred' in f]))
+
+    metric_suffix_lst = ['_unc-vox', '_unc-cv', '_unc-avgUnc']
+    for metric in metric_lst:
+        print(metric)
+        for subj_acq in subj_acq_lst:
+            fname = os.path.join(pred_folder, subj_acq+metric+'.nii.gz')
+            im = nib.load(fname)
+            data = im.get_data()
+            vals = list(data[np.non_zero(data)])
+            print(np.min(vals), np.mean(vals), np.median(vals), np.max(vals))
+
+if __name__ == '__main__':
+    parser = get_parser()
+    arguments = parser.parse_args()
+    run_main(arguments)

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -129,6 +129,13 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
 
     return res_dct
 
+
+def print_retained_elt(thr_unc_lst, retained_elt_lst):
+    print('Mean percentage of retained elt:')
+    for i, t in thr_unc_lst:
+       print('\tUnc threshold: {} --> {}'.format(t, np.mean(retained_elt_lst[i])))
+
+
 def run_main(args):
 
     with open(args.c, "r") as fhandle:
@@ -180,64 +187,7 @@ def run_main(args):
                                 target_suf=context["target_suffix"],
                                 param_eval=context["eval_params"])
 
-        print([np.mean(res['retained_elt'][i]) for i, t in enumerate(config_dct['uncertainty_thr'])])
-
-"""
-        for subj_acq in subj_acq_lst:
-            fname_unc = os.path.join(pred_folder, subj_acq+metric+'.nii.gz')
-            im = nib.load(fname_unc)
-            data_unc = im.get_data()
-#            print(np.percentile(data_unc, 25), np.median(data_unc), np.percentile(data_unc, 75), np.max(data_unc))
-            del im
-
-            data_pred_lst = np.array([nib.load(os.path.join(pred_folder, f)).get_data()
-                                for f in os.listdir(pred_folder) if subj_acq+'_pred_' in f])
-
-            fname_gt = os.path.join(gt_folder, subj_acq.split('_')[0], 'anat', subj_acq+context["target_suffix"]+'.nii.gz')
-            if os.path.isfile(fname_gt):
-                nib_gt = nib.load(fname_gt)
-                data_gt = nib_gt.get_data()
-
-                for i_unc, thr_unc in enumerate(thr_unc_lst):
-                    data_prob = np.mean(data_pred_lst, axis=0)
-
-                    data_prob_thrUnc = deepcopy(data_prob)
-                    data_prob_thrUnc[data_unc > thr_unc] = 0
-
-                    cmpt_vox_beforeThr = np.count_nonzero(data_prob)
-                    cmpt_vox_afterThr = np.count_nonzero(data_prob_thrUnc)
-                    percent_rm_vox = (cmpt_vox_beforeThr - cmpt_vox_afterThr) * 100. / cmpt_vox_beforeThr
-                    percent_retained_vox = 100. - percent_rm_vox
-
-                    _, n_beforeThr = label((data_prob > 0).astype(np.int), structure=BIN_STRUCT)
-                    _, n_afterThr = label((data_prob_thrUnc > 0).astype(np.int), structure=BIN_STRUCT)
-                    percent_retained_obj = 100. - ((n_beforeThr - n_afterThr) * 100. / n_beforeThr)
-
-                    results_dct[metric]['retained_vox'][i_unc].append(percent_retained_vox)
-                    results_dct[metric]['retained_obj'][i_unc].append(percent_retained_obj)
-        print(results_dct[metric]['retained_obj'], results_dct[metric]['retained_vox'])
-                    for i_vox, thr_vox in enumerate(thr_vox_lst):
-                        data_hard = threshold_predictions(deepcopy(data_prob_thrUnc), thr=thr_vox).astype(np.uint8)
-
-                        eval = Evaluation3DMetrics(data_pred=data_hard,
-                                                    data_gt=data_gt,
-                                                    dim_lst=nib_gt.header['pixdim'][1:4],
-                                                    params=context['eval_params'])
-
-                        tpr_vox = mt_metrics.recall_score(eval.data_pred, eval.data_gt, err_value=np.nan)
-                        fdr_vox = 100. - mt_metrics.precision_score(eval.data_pred, eval.data_gt, err_value=np.nan)
-                        tpr_obj, _ = eval.get_ltpr()
-                        fdr_obj = eval.get_lfdr()
-
-#                        print(thr_vox, tpr_vox, fdr_vox, tpr_obj, fdr_obj)
-
-                        results_dct[metric]['tpr_vox'][i_unc][i_vox].append(tpr_vox / 100.)
-                        results_dct[metric]['fdr_vox'][i_unc][i_vox].append(fdr_vox / 100.)
-                        results_dct[metric]['tpr_obj'][i_unc][i_vox].append(tpr_obj / 100.)
-                        results_dct[metric]['fdr_obj'][i_unc][i_vox].append(fdr_obj / 100.)
-
-    for metric in metric_suffix_lst:
-        print('Metric: {}'.format(metric))
+        print_retained_elt(thr_unc_lst=config_dct['uncertainty_thr'], retained_elt_lst=res['retained_elt'])
 
         plt.figure(figsize=(10,10))
         for i_unc, thr_unc in enumerate(thr_unc_lst):
@@ -270,7 +220,7 @@ def run_main(args):
         fname_out = os.path.join(ofolder, metric+'.png')
         plt.savefig(fname_out, bbox_inches='tight', pad_inches=0)
         plt.close()
-"""
+
 if __name__ == '__main__':
     parser = get_parser()
     arguments = parser.parse_args()

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -97,30 +97,31 @@ def run_main(args):
                                 for f in os.listdir(pred_folder) if subj_acq+'_pred_' in f]
 
             fname_gt = os.path.join(gt_folder, subj_acq.split('_')[0], 'anat', subj_acq+context["target_suffix"]+'.nii.gz')
-            data_gt = nib.load(fname_gt).get_data()
-            data_gt = remove_small_obj(data_gt, MIN_OBJ_SIZE, BIN_STRUCT)
+            if os.path.isfile(fname_gt):
+                data_gt = nib.load(fname_gt).get_data()
+                data_gt = remove_small_obj(data_gt, MIN_OBJ_SIZE, BIN_STRUCT)
 
-            for i_unc, thr_unc in enumerate(thr_unc_lst):
-                data_unc_thr = (deepcopy(data_unc) > thr_unc).astype(np.int)
+                for i_unc, thr_unc in enumerate(thr_unc_lst):
+                    data_unc_thr = (deepcopy(data_unc) > thr_unc).astype(np.int)
 
-                data_pred_thrUnc_lst = [d * deepcopy(data_unc_thr) for d in data_pred_lst]
+                    data_pred_thrUnc_lst = [d * deepcopy(data_unc_thr) for d in data_pred_lst]
 
-                data_prob = np.mean(np.array(data_pred_thrUnc_lst), axis=0)
+                    data_prob = np.mean(np.array(data_pred_thrUnc_lst), axis=0)
 
-                for i_vox, thr_vox in enumerate(thr_vox_lst):
-                    data_hard = threshold_predictions(deepcopy(data_prob), thr=thr_vox).astype(np.uint8)
+                    for i_vox, thr_vox in enumerate(thr_vox_lst):
+                        data_hard = threshold_predictions(deepcopy(data_prob), thr=thr_vox).astype(np.uint8)
 
-                    data_hard = remove_small_obj(data_hard, MIN_OBJ_SIZE, BIN_STRUCT)
+                        data_hard = remove_small_obj(data_hard, MIN_OBJ_SIZE, BIN_STRUCT)
 
-                    tpr_vox = mt_metrics.recall_score(data_hard, data_gt, err_value=np.nan)
-                    fdr_vox = 100. - mt_metrics.precision_score(data_hard, data_gt, err_value=np.nan)
-                    #tpr_obj =
-                    #fdr_obj =
+                        tpr_vox = mt_metrics.recall_score(data_hard, data_gt, err_value=np.nan)
+                        fdr_vox = 100. - mt_metrics.precision_score(data_hard, data_gt, err_value=np.nan)
+                        #tpr_obj =
+                        #fdr_obj =
 
-                    results_dct[metric]['tpr_vox'][i_unc][i_vox].append(tpr_vox / 100.)
-                    results_dct[metric]['fdr_vox'][i_unc][i_vox].append(fdr_vox / 100.)
-                    #results_dct[metric]['tpr_obj'][i_unc][i_vox].append(tpr_obj)
-                    #results_dct[metric]['fdr_obj'][i_unc][i_vox].append(fdr_obj)
+                        results_dct[metric]['tpr_vox'][i_unc][i_vox].append(tpr_vox / 100.)
+                        results_dct[metric]['fdr_vox'][i_unc][i_vox].append(fdr_vox / 100.)
+                        #results_dct[metric]['tpr_obj'][i_unc][i_vox].append(tpr_obj)
+                        #results_dct[metric]['fdr_obj'][i_unc][i_vox].append(fdr_obj)
 
 
     for metric in metric_suffix_lst:

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -250,7 +250,6 @@ def run_main(args):
     subj_acq_lst = list(set([f.split('_pred')[0] for f in os.listdir(pred_folder)
                     if f.endswith('.nii.gz') and '_pred' in f]))
     #subj_acq_lst = [subj_acq_lst[0]]
-    print(subj_acq_lst)
     gt_folder = os.path.join(context['bids_path'], 'derivatives', 'labels')
 
     if thrPred is None:

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -121,10 +121,8 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
             if np.any(data_soft):
                 for i_unc, thr_unc in enumerate(thr_unc_lst):
                     # discard uncertain lesions from data_soft
-                    print(thr_unc)
                     data_soft_thrUnc = deepcopy(data_soft)
                     data_soft_thrUnc[data_unc > thr_unc] = 0
-                    print(np.sum(data_soft), np.sum(data_soft_thrUnc))
                     cmpt = count_retained((data_soft > 0).astype(np.int), (data_soft_thrUnc > 0).astype(np.int), level)
                     res_dct['retained_elt'][i_unc].append(cmpt)
 
@@ -142,8 +140,6 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
                         else:
                             tpr, _ = eval.get_ltpr()
                             fdr = eval.get_lfdr()
-
-                        print(thr_pred, tpr, fdr)
 
                         res_dct['tpr'][i_unc][i_pred].append(tpr / 100.)
                         res_dct['fdr'][i_unc][i_pred].append(fdr / 100.)

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -6,6 +6,7 @@
 
 import os
 import json
+import joblib
 import argparse
 import pandas as pd
 import numpy as np
@@ -259,15 +260,21 @@ def run_main(args):
             # print_unc_stats is used to determine 'uncertainty_thr'
             print_unc_stats(config_dct['uncertainty_measure'], pred_folder, subj_acq_lst)
 
-            res = run_experiment(level=config_dct['level'],
-                                    unc_name=config_dct['uncertainty_measure'],
-                                    thr_unc_lst=config_dct['uncertainty_thr'],
-                                    thr_pred_lst=config_dct['prediction_thr'],
-                                    gt_folder=gt_folder,
-                                    pred_folder=pred_folder,
-                                    im_lst=subj_acq_lst,
-                                    target_suf=context["target_suffix"],
-                                    param_eval=context["eval_params"])
+            res_ofname = os.path.join(ofolder, config_dct['uncertainty_measure']+'.joblib')
+            if not os.path.isfile(res_ofname):
+                res = run_experiment(level=config_dct['level'],
+                                        unc_name=config_dct['uncertainty_measure'],
+                                        thr_unc_lst=config_dct['uncertainty_thr'],
+                                        thr_pred_lst=config_dct['prediction_thr'],
+                                        gt_folder=gt_folder,
+                                        pred_folder=pred_folder,
+                                        im_lst=subj_acq_lst,
+                                        target_suf=context["target_suffix"],
+                                        param_eval=context["eval_params"])
+                joblib.dump(res, res_ofname)
+            else:
+                joblib.load(res_ofname)
+
             """
             print_retained_elt(thr_unc_lst=config_dct['uncertainty_thr'], retained_elt_lst=res['retained_elt'])
 

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -101,7 +101,7 @@ def run_main(args):
                 data_gt = remove_small_obj(data_gt, MIN_OBJ_SIZE, BIN_STRUCT)
 
                 for i_unc, thr_unc in enumerate(thr_unc_lst):
-                    data_unc_thr = (deepcopy(data_unc) > thr_unc).astype(np.int)
+                    data_unc_thr = (deepcopy(data_unc) < thr_unc).astype(np.int)
 
                     data_pred_thrUnc_lst = [d * deepcopy(data_unc_thr) for d in data_pred_lst]
 

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -26,8 +26,8 @@ MIN_OBJ_SIZE = 3
 exp_dct = {
                 'exp1': {'level': 'vox',
                             'uncertainty_measure': '_unc-vox',
-                            'uncertainty_thr': [1e-5, 1e-3, 1e-1, 0.5],
-                            'prediction_thr': [1e-6]+[t/10. for t in range(1,10,1)]}
+                            'uncertainty_thr': [1e-3, 1e-2, 0.1, 0.2, 0.4, 0.6],
+                            'prediction_thr': [t/10. for t in range(1,10,1)]}
 #                'exp2': {'level': 'obj',
 #                            'uncertainty_measure': '_unc-cv',
 #                            'uncertainty_thr': [0.1, 0.2, 0.3, 0.4, 0.5],
@@ -66,8 +66,8 @@ def print_unc_stats(unc_name, pred_folder, im_lst):
         im = nib.load(fname_unc)
         data_unc = im.get_data()
         del im
-        if np.any(data_unc):
-            vals = list(data_unc[data_unc > 0])
+        vals = list(data_unc[data_unc > 0])
+        if len(vals):
             mins.append(np.min(vals))
             maxs.append(np.max(vals))
             p25s.append(np.percentile(vals, 25))
@@ -118,13 +118,13 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
             # soft prediction
             data_soft = np.mean(data_pred_lst, axis=0)
 
-            if np.any(data_gt) and np.any(data_soft):
+            if np.any(data_soft):
                 for i_unc, thr_unc in enumerate(thr_unc_lst):
                     # discard uncertain lesions from data_soft
-                    #print(thr_unc)
+                    print(thr_unc)
                     data_soft_thrUnc = deepcopy(data_soft)
                     data_soft_thrUnc[data_unc > thr_unc] = 0
-                    #print(np.sum(data_soft), np.sum(data_soft_thrUnc))
+                    print(np.sum(data_soft), np.sum(data_soft_thrUnc))
                     cmpt = count_retained((data_soft > 0).astype(np.int), (data_soft_thrUnc > 0).astype(np.int), level)
                     res_dct['retained_elt'][i_unc].append(cmpt)
 
@@ -143,7 +143,7 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
                             tpr, _ = eval.get_ltpr()
                             fdr = eval.get_lfdr()
 
-                        #print(thr_pred, tpr, fdr)
+                        print(thr_pred, tpr, fdr)
 
                         res_dct['tpr'][i_unc][i_pred].append(tpr / 100.)
                         res_dct['fdr'][i_unc][i_pred].append(fdr / 100.)
@@ -272,7 +272,7 @@ def run_main(args):
                                     im_lst=subj_acq_lst,
                                     target_suf=context["target_suffix"],
                                     param_eval=context["eval_params"])
-
+            """
             print_retained_elt(thr_unc_lst=config_dct['uncertainty_thr'], retained_elt_lst=res['retained_elt'])
 
             plot_roc(thr_unc_lst=config_dct['uncertainty_thr'],
@@ -280,7 +280,7 @@ def run_main(args):
                         res_dct=res,
                         metric=config_dct['uncertainty_measure'],
                         fname_out=os.path.join(ofolder, config_dct['uncertainty_measure']+'.png'))
-
+           """
     else:
         df = run_inference(pred_folder=pred_folder,
                             im_lst=subj_acq_lst,

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -99,14 +99,13 @@ def run_main(args):
                     percent_rm_vox = (cmpt_vox_beforeThr - cmpt_vox_afterThr) * 100. / cmpt_vox_beforeThr
                     percent_retained_vox = 100. - percent_rm_vox
 
-                    _, n_beforeThr = label((data_prob > 0).astype(np.int), struct=BIN_STRUCT)
-                    _, n_afterThr = label((data_prob_thrUnc > 0).astype(np.int), struct=BIN_STRUCT)
-                    percent_reatined_obj = 100. - (n_beforeThr - n_afterThr) * 100. / n_beforeThr
+                    _, n_beforeThr = label((data_prob > 0).astype(np.int), structure=BIN_STRUCT)
+                    _, n_afterThr = label((data_prob_thrUnc > 0).astype(np.int), structure=BIN_STRUCT)
+                    percent_retained_obj = 100. - ((n_beforeThr - n_afterThr) * 100. / n_beforeThr)
 
                     results_dct[metric]['retained_vox'][i_unc].append(percent_retained_vox)
                     results_dct[metric]['retained_obj'][i_unc].append(percent_retained_obj)
 
-"""
                     for i_vox, thr_vox in enumerate(thr_vox_lst):
                         data_hard = threshold_predictions(deepcopy(data_prob_thrUnc), thr=thr_vox).astype(np.uint8)
 
@@ -120,13 +119,12 @@ def run_main(args):
                         tpr_obj, _ = eval.get_ltpr()
                         fdr_obj = eval.get_lfdr()
 
-                        print(thr_vox, tpr_vox, fdr_vox, tpr_obj, fdr_obj)
+#                        print(thr_vox, tpr_vox, fdr_vox, tpr_obj, fdr_obj)
 
                         results_dct[metric]['tpr_vox'][i_unc][i_vox].append(tpr_vox / 100.)
                         results_dct[metric]['fdr_vox'][i_unc][i_vox].append(fdr_vox / 100.)
                         results_dct[metric]['tpr_obj'][i_unc][i_vox].append(tpr_obj / 100.)
                         results_dct[metric]['fdr_obj'][i_unc][i_vox].append(fdr_obj / 100.)
-"""
 
     for metric in metric_suffix_lst:
         print('Metric: {}'.format(metric))
@@ -139,7 +137,6 @@ def run_main(args):
             mean_retained_obj = np.mean(results_dct[metric]['retained_obj'][i_unc])
             print('Mean percentage of retained voxels: {}%, lesions: {}%.'.format(thr_unc, mean_retained_vox, mean_retained_obj))
 
-"""
             tpr_vals = np.array([np.nanmean(results_dct[metric]['tpr_vox'][i_unc][i_vox]) for i_vox in range(len(thr_vox_lst))])
             fdr_vals = np.array([np.nanmean(results_dct[metric]['fdr_vox'][i_unc][i_vox]) for i_vox in range(len(thr_vox_lst))])
 
@@ -163,7 +160,6 @@ def run_main(args):
         fname_out = os.path.join(ofolder, metric+'.png')
         plt.savefig(fname_out, bbox_inches='tight', pad_inches=0)
         plt.close()
-    """
 
 if __name__ == '__main__':
     parser = get_parser()

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -24,6 +24,9 @@ MIN_OBJ_SIZE = 3
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", help="Config file path.")
+    parser.add_argument("-thrUnc", help="Threshold to apply on uncertainty map.")
+    parser.add_argument("-thrPred", help="Threshold to apply on prediction.")
+    parser.add_argument("-suffixUnc", help="Suffix of the uncertainty map to use (e.g. _unc-vox).")
     parser.add_argument("-ofolder", help="Output folder.")
 
     return parser

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -11,6 +11,7 @@ import numpy as np
 import nibabel as nib
 from copy import deepcopy
 from sklearn.metrics import auc
+import matplotlib.pyplot as plt
 from scipy.ndimage import label, generate_binary_structure
 
 from ivadomed.main import cmd_test
@@ -126,6 +127,8 @@ def run_main(args):
 
     for metric in metric_suffix_lst:
         print('Metric: {}'.format(metric))
+
+        plt.figure(figsize=(10,10))
         for i_unc, thr_unc in enumerate(thr_unc_lst):
             print('Unc Thr: {}'.format(thr_unc))
             tpr_vals = np.array([np.nanmean(results_dct[metric]['tpr_vox'][i_unc][i_vox]) for i_vox in range(len(thr_vox_lst))])
@@ -138,6 +141,20 @@ def run_main(args):
             optimal_idx = np.argmax(tpr_vals - fdr_vals)
             optimal_threshold = thr_vox_lst[optimal_idx]
             print('AUC: {}, Optimal Pred Thr: {}'.format(auc_, optimal_threshold))
+
+            plt.plot(fdr_vals, tpr_vals, label='Unc thr={0:0.2f} (area = {1:0.2f})'.format(thr_unc, auc_))
+
+        plt.plot([0, 1], [0, 1], 'k--')
+        plt.xlim([0.0, 1.0])
+        plt.ylim([0.0, 1.05])
+        plt.xlabel('False Detection Rate')
+        plt.ylabel('True Positive Rate')
+        plt.title('Receiver operating characteristic example')
+        plt.legend(loc="lower right")
+        fname_out = os.path.join(ofolder, metric+'.png')
+        plt.save(fname_out, bbox_inches='tight', pad_inches=0
+        plt.close()
+
 
 if __name__ == '__main__':
     parser = get_parser()

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -33,17 +33,19 @@ def run_main(args):
         cmd_test(context)
 
     subj_acq_lst = list(set([f.split('_pred')[0] for f in os.listdir(pred_folder)
-                    if f.endswith('.nii.gz') and '_pred' in f]))
+                    if f.endswith('.nii.gz') and '_pred' in f]))[:5]
 
     metric_suffix_lst = ['_unc-vox', '_unc-cv', '_unc-avgUnc']
-    for metric in metric_lst:
+    thr_lst = [0.01, 0.1, 0.5]
+    for metric in metric_suffix_lst:
         print(metric)
         for subj_acq in subj_acq_lst:
             fname = os.path.join(pred_folder, subj_acq+metric+'.nii.gz')
             im = nib.load(fname)
             data = im.get_data()
-            vals = list(data[np.non_zero(data)])
+            vals = list(data[np.nonzero(data)])
             print(np.min(vals), np.mean(vals), np.median(vals), np.max(vals))
+            del im
 
 if __name__ == '__main__':
     parser = get_parser()

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -103,12 +103,12 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
                     print(thr_unc)
                     data_soft_thrUnc = deepcopy(data_soft)
                     data_soft_thrUnc[data_unc > thr_unc] = 0
-                    print(np.sum(data_soft), np.sum(data_soft_thrUnc))
+                    #print(np.sum(data_soft), np.sum(data_soft_thrUnc))
                     cmpt = count_retained((data_soft > 0).astype(np.int), (data_soft_thrUnc > 0).astype(np.int), level)
                     res_dct['retained_elt'][i_unc].append(cmpt)
 
-                    for i_vox, thr_vox in enumerate(thr_pred_lst):
-                        data_hard = threshold_predictions(deepcopy(data_prob_thrUnc), thr=thr_vox).astype(np.uint8)
+                    for i_pred, thr_pred in enumerate(thr_pred_lst):
+                        data_hard = threshold_predictions(deepcopy(data_soft_thrUnc), thr=thr_pred).astype(np.uint8)
 
                         eval = Evaluation3DMetrics(data_pred=data_hard,
                                                     data_gt=data_gt,
@@ -116,16 +116,16 @@ def run_experiment(level, unc_name, thr_unc_lst, thr_pred_lst, gt_folder, pred_f
                                                     params=param_eval)
 
                         if level == 'vox':
-                            tpr_vox = mt_metrics.recall_score(eval.data_pred, eval.data_gt, err_value=np.nan)
-                            fdr_vox = 100. - mt_metrics.precision_score(eval.data_pred, eval.data_gt, err_value=np.nan)
+                            tpr = mt_metrics.recall_score(eval.data_pred, eval.data_gt, err_value=np.nan)
+                            fdr = 100. - mt_metrics.precision_score(eval.data_pred, eval.data_gt, err_value=np.nan)
                         else:
                             tpr, _ = eval.get_ltpr()
                             fdr = eval.get_lfdr()
 
-                        print(thr_vox, tpr, fdr)
+                        print(thr_pred, tpr, fdr)
 
-                        results_dct[metric]['tpr'][i_unc][i_vox].append(tpr / 100.)
-                        results_dct[metric]['fdr'][i_unc][i_vox].append(fdr / 100.)
+                        res_dct['tpr'][i_unc][i_pred].append(tpr / 100.)
+                        res_dct['fdr'][i_unc][i_pred].append(fdr / 100.)
 
     return res_dct
 

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -9,10 +9,13 @@ import json
 import argparse
 import numpy as np
 import nibabel as nib
+from copy import deepcopy
+from sklearn.metrics import auc
 from scipy.ndimage import label, generate_binary_structure
 
 from ivadomed.main import cmd_test
 from ivadomed.utils import threshold_predictions
+from medicaltorch import metrics as mt_metrics
 
 BIN_STRUCT = generate_binary_structure(3,2)
 MIN_OBJ_SIZE = 3
@@ -25,7 +28,7 @@ def get_parser():
     return parser
 
 # TODO: remove once moved out of Evaluation3Dmetrics
-def remove_small_obj(data, size_min, bin_struct)
+def remove_small_obj(data, size_min, bin_struct):
     data_label, n = label(data,
                           structure=bin_struct)
 
@@ -37,6 +40,18 @@ def remove_small_obj(data, size_min, bin_struct)
             data[data_label == idx] = 0
 
     return data
+
+
+# def auc_homemade(fpr, tpr, trapezoid=False):
+#     # source: https://stackoverflow.com/a/39687168
+
+#     inds = [i for (i, (s, e)) in enumerate(zip(fpr[: -1], fpr[1: ])) if s != e] + [len(fpr) - 1]
+#     fpr, tpr = fpr[inds], tpr[inds]
+#     area = 0
+#     ft = zip(fpr, tpr)
+#     for p0, p1 in list(zip(ft[: -1], ft[1: ])):
+#         area += (p1[0] - p0[0]) * ((p1[1] + p0[1]) / 2 if trapezoid else p0[1])
+#     return area
 
 def run_main(args):
 
@@ -52,7 +67,7 @@ def run_main(args):
         cmd_test(context)
 
     subj_acq_lst = list(set([f.split('_pred')[0] for f in os.listdir(pred_folder)
-                    if f.endswith('.nii.gz') and '_pred' in f]))[:5]
+                    if f.endswith('.nii.gz') and '_pred' in f]))
 
     gt_folder = os.path.join(context['bids_path'], 'derivatives', 'labels')
 
@@ -61,39 +76,39 @@ def run_main(args):
     thr_vox_lst = [t/10. for t in range(0,10,1)]
     results_dct = {}
     for metric in metric_suffix_lst:
-        print(metric)
 
-        res_init_lst = [[[]] * len(thr_vox_lst)] * len(thr_unc_lst)
-        results_dct[metric] = {'tpr_vox': res_init_lst,
-                                'fdr_vox': res_init_lst,
+        tmp_lst = [[] for _ in range(len(thr_vox_lst))]
+        res_init_lst = [deepcopy(tmp_lst) for _ in range(len(thr_unc_lst))]
+
+        results_dct[metric] = {'tpr_vox': deepcopy(res_init_lst),
+                                'fdr_vox': deepcopy(res_init_lst),
                                 # TODO: modify ltpr and lfdr so that callable here
-                                # 'tpr_obj': res_init_lst,
-                                # 'fdr_obj': res_init_lst
+                                # 'tpr_obj': deepcopy(res_init_lst),
+                                # 'fdr_obj': deepcopy(res_init_lst)
                                 }
 
         for subj_acq in subj_acq_lst:
             fname_unc = os.path.join(pred_folder, subj_acq+metric+'.nii.gz')
-            im = nib.load(fname)
+            im = nib.load(fname_unc)
             data_unc = im.get_data()
             del im
 
             data_pred_lst = [nib.load(os.path.join(pred_folder, f)).get_data()
                                 for f in os.listdir(pred_folder) if subj_acq+'_pred_' in f]
 
-            fname_gt = os.path.join(gt_folder, subj_acq, 'anat', subj_acq+context["target_suffix"]+'.nii.gz')
+            fname_gt = os.path.join(gt_folder, subj_acq.split('_')[0], 'anat', subj_acq+context["target_suffix"]+'.nii.gz')
             data_gt = nib.load(fname_gt).get_data()
-
             data_gt = remove_small_obj(data_gt, MIN_OBJ_SIZE, BIN_STRUCT)
 
             for i_unc, thr_unc in enumerate(thr_unc_lst):
-                data_unc_thr = (data_unc > thr_unc).astype(np.int)
+                data_unc_thr = (deepcopy(data_unc) > thr_unc).astype(np.int)
 
-                data_pred_thrUnc_lst = [d * data_unc_thr for d in data_pred_lst]
+                data_pred_thrUnc_lst = [d * deepcopy(data_unc_thr) for d in data_pred_lst]
 
                 data_prob = np.mean(np.array(data_pred_thrUnc_lst), axis=0)
 
                 for i_vox, thr_vox in enumerate(thr_vox_lst):
-                    data_hard = threshold_predictions(data_prob, thr=thr_vox).astype(np.uint8)
+                    data_hard = threshold_predictions(deepcopy(data_prob), thr=thr_vox).astype(np.uint8)
 
                     data_hard = remove_small_obj(data_hard, MIN_OBJ_SIZE, BIN_STRUCT)
 
@@ -102,12 +117,26 @@ def run_main(args):
                     #tpr_obj =
                     #fdr_obj =
 
-                    results_dct[metric]['tpr_vox'][i_unc][i_vox].append(tpr_vox)
-                    results_dct[metric]['fdr_vox'][i_unc][i_vox].append(fdr_vox)
+                    results_dct[metric]['tpr_vox'][i_unc][i_vox].append(tpr_vox / 100.)
+                    results_dct[metric]['fdr_vox'][i_unc][i_vox].append(fdr_vox / 100.)
                     #results_dct[metric]['tpr_obj'][i_unc][i_vox].append(tpr_obj)
                     #results_dct[metric]['fdr_obj'][i_unc][i_vox].append(fdr_obj)
 
-    print(results_dct['_unc-vox'])
+
+    for metric in metric_suffix_lst:
+        print('Metric: {}'.format(metric))
+        for i_unc, thr_unc in enumerate(thr_unc_lst):
+            print('Unc Thr: {}'.format(thr_unc))
+            tpr_vals = np.array([np.nanmean(results_dct[metric]['tpr_vox'][i_unc][i_vox]) for i_vox in range(len(thr_vox_lst))])
+            fdr_vals = np.array([np.nanmean(results_dct[metric]['fdr_vox'][i_unc][i_vox]) for i_vox in range(len(thr_vox_lst))])
+
+            auc_ = auc(fdr_vals, tpr_vals)          
+            # auc_ = auc_homemade(fdr_vals, tpr_vals)
+            # auc__ = auc_homemade(fdr_vals, tpr_vals, True)
+            
+            optimal_idx = np.argmax(tpr_vals - fdr_vals)
+            optimal_threshold = thr_vox_lst[optimal_idx]
+            print('AUC: {}, Optimal Pred Thr: {}'.format(auc_, optimal_threshold))
 
 if __name__ == '__main__':
     parser = get_parser()

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -292,8 +292,9 @@ def run_main(args):
                             unc_name=sufUnc,
                             thr_unc=thrUnc)
         print(df.head())
-        print('Median (IQR): {} ({} - {}).'.format(np.mean(df.dice), np.percentile(df.dice, 25), np.percentile(df.dice, 75)))
-        df.to_csv(os.path.join(ofolder, '_'.join([sufUnc, str(thrUnc), str(thrPred)])+'.csv'))
+        vals = [v for v in df.dice_class0 if str(v) != 'nan']
+        print('Median (IQR): {} ({} - {}).'.format(np.median(vals), np.percentile(vals, 25), np.percentile(vals, 75)))
+        df.to_csv(os.path.join(ofolder, '_'.join([str(sufUnc), str(thrUnc), str(thrPred)])+'.csv'))
 
 if __name__ == '__main__':
     parser = get_parser()

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -183,7 +183,10 @@ def plot_roc(thr_unc_lst, thr_pred_lst, res_dct, metric, fname_out):
     plt.close()
 
 
-def run_inference(im_lst, fname_pref, thr_pred, gt_folder, target_suf, param_eval, unc_name=None, thr_unc=None):
+def run_inference(pred_folder, im_lst, fname_pref, thr_pred, gt_folder, target_suf, param_eval, unc_name=None, thr_unc=None):
+    # init df
+    df_results = pd.DataFrame()
+
     # loop across images
     for fname_pref in im_lst:
         if None in [unc_name, thr_unc]:
@@ -222,13 +225,16 @@ def run_inference(im_lst, fname_pref, thr_pred, gt_folder, target_suf, param_eva
         results_pred, _ = eval.run_eval()
 
         # save results of this fname_pred
-        results_pred['image_id'] = subj_acq
+        results_pred['image_id'] = fname_pref.split('_')[0]
         df_results = df_results.append(results_pred, ignore_index=True)
 
     return df_results
 
 
 def run_main(args):
+    thrPred = args.
+    thrUnc = args.
+    sufUnc = args.
 
     with open(args.c, "r") as fhandle:
         context = json.load(fhandle)
@@ -260,7 +266,7 @@ def run_main(args):
                                     thr_pred_lst=config_dct['prediction_thr'],
                                     gt_folder=gt_folder,
                                     pred_folder=pred_folder,
-                                    im_lst=subj_acq_lst[:30],
+                                    im_lst=subj_acq_lst,
                                     target_suf=context["target_suffix"],
                                     param_eval=context["eval_params"])
 
@@ -273,7 +279,17 @@ def run_main(args):
                         fname_out=os.path.join(ofolder, config_dct['uncertainty_measure']+'.png'))
 
     else:
-        pass
+        df = run_inference(pred_folder=pred_folder,
+                            im_lst=subj_acq_lst,
+                            fname_pref,
+                            thr_pred=thrPred,
+                            gt_folder=gt_folder,
+                            target_suf=context["target_suffix"],
+                            param_eval=context["eval_params"],
+                            unc_name=sufUnc,
+                            thr_unc=thrUnc)
+        print(df.head())
+        df.to_csv(os.path.join(ofolder, '_'.join([sufUnc, str(thrUnc), str(thrPred)])+'.csv'))
 
 if __name__ == '__main__':
     parser = get_parser()

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -56,9 +56,25 @@ def run_main(args):
 
     gt_folder = os.path.join(context['bids_path'], 'derivatives', 'labels')
 
-    metric_suffix_lst = ['_unc-vox']  #['_unc-vox', '_unc-cv', '_unc-avgUnc']
-    thr_unc_lst = [1e-5, 1e-3, 1e-1, 0.5]  #[0.0001, 0.001, 0.01, 0.1, 0.5]
-    thr_vox_lst = [1e-6]+[t/10. for t in range(1,10,1)]
+    # experiments
+    exp_dct = {
+                'exp1': {'level': 'vox',
+                            'uncertainty_measure': '_unc-vox',
+                            'uncertainty_thr': [1e-5, 1e-3, 1e-1, 0.5],
+                            'prediction_thr': [1e-6]+[t/10. for t in range(1,10,1)],
+                            'results': {}},
+                'exp2': {'level': 'obj',
+                            'uncertainty_measure': '_unc-cv',
+                            'uncertainty_thr': [1e-5, 1e-3, 1e-1, 0.5],
+                            'prediction_thr': [1e-6]+[t/10. for t in range(1,10,1)],
+                            'results': {}},
+                'exp3': {'level': 'obj',
+                            'uncertainty_measure': '_unc-avgUnc',
+                            'uncertainty_thr': [1e-5, 1e-3, 1e-1, 0.5],
+                            'prediction_thr': [1e-6]+[t/10. for t in range(1,10,1)],
+                            'results': {}}
+    }
+
     results_dct = {}
     for metric in metric_suffix_lst:
         print(metric)
@@ -105,7 +121,8 @@ def run_main(args):
 
                     results_dct[metric]['retained_vox'][i_unc].append(percent_retained_vox)
                     results_dct[metric]['retained_obj'][i_unc].append(percent_retained_obj)
-
+        print(results_dct[metric]['retained_obj'], results_dct[metric]['retained_vox'])
+"""
                     for i_vox, thr_vox in enumerate(thr_vox_lst):
                         data_hard = threshold_predictions(deepcopy(data_prob_thrUnc), thr=thr_vox).astype(np.uint8)
 
@@ -160,7 +177,7 @@ def run_main(args):
         fname_out = os.path.join(ofolder, metric+'.png')
         plt.savefig(fname_out, bbox_inches='tight', pad_inches=0)
         plt.close()
-
+"""
 if __name__ == '__main__':
     parser = get_parser()
     arguments = parser.parse_args()

--- a/dev/filtering_lesion.py
+++ b/dev/filtering_lesion.py
@@ -70,7 +70,7 @@ def run_main(args):
                                 'retained_vox': [[] for _ in range(len(thr_unc_lst))],
                                 'tpr_obj': deepcopy(res_init_lst),
                                 'fdr_obj': deepcopy(res_init_lst),
-                                # TODO: reatined_l
+                                'retained_obj': [[] for _ in range(len(thr_unc_lst))]
                                 }
 
         for subj_acq in subj_acq_lst:
@@ -99,9 +99,14 @@ def run_main(args):
                     percent_rm_vox = (cmpt_vox_beforeThr - cmpt_vox_afterThr) * 100. / cmpt_vox_beforeThr
                     percent_retained_vox = 100. - percent_rm_vox
 
+                    _, n_beforeThr = label((data_prob > 0).astype(np.int), struct=BIN_STRUCT)
+                    _, n_afterThr = label((data_prob_thrUnc > 0).astype(np.int), struct=BIN_STRUCT)
+                    percent_reatined_obj = 100. - (n_beforeThr - n_afterThr) * 100. / n_beforeThr
+
                     results_dct[metric]['retained_vox'][i_unc].append(percent_retained_vox)
-                    print(' ')
-                    print(thr_unc)
+                    results_dct[metric]['retained_obj'][i_unc].append(percent_retained_obj)
+
+"""
                     for i_vox, thr_vox in enumerate(thr_vox_lst):
                         data_hard = threshold_predictions(deepcopy(data_prob_thrUnc), thr=thr_vox).astype(np.uint8)
 
@@ -121,17 +126,20 @@ def run_main(args):
                         results_dct[metric]['fdr_vox'][i_unc][i_vox].append(fdr_vox / 100.)
                         results_dct[metric]['tpr_obj'][i_unc][i_vox].append(tpr_obj / 100.)
                         results_dct[metric]['fdr_obj'][i_unc][i_vox].append(fdr_obj / 100.)
-
-        for i_unc, thr_unc in enumerate(thr_unc_lst):
-            mean_retained_vox = np.mean(results_dct[metric]['retained_vox'][i_unc])
-            print('\tUnc threshold: {} --> Mean percentage of retained voxels: {}%.'.format(thr_unc, mean_retained_vox))
 """
+
     for metric in metric_suffix_lst:
         print('Metric: {}'.format(metric))
 
         plt.figure(figsize=(10,10))
         for i_unc, thr_unc in enumerate(thr_unc_lst):
             print('Unc Thr: {}'.format(thr_unc))
+
+            mean_retained_vox = np.mean(results_dct[metric]['retained_vox'][i_unc])
+            mean_retained_obj = np.mean(results_dct[metric]['retained_obj'][i_unc])
+            print('Mean percentage of retained voxels: {}%, lesions: {}%.'.format(thr_unc, mean_retained_vox, mean_retained_obj))
+
+"""
             tpr_vals = np.array([np.nanmean(results_dct[metric]['tpr_vox'][i_unc][i_vox]) for i_vox in range(len(thr_vox_lst))])
             fdr_vals = np.array([np.nanmean(results_dct[metric]['fdr_vox'][i_unc][i_vox]) for i_vox in range(len(thr_vox_lst))])
 

--- a/ivadomed/loader.py
+++ b/ivadomed/loader.py
@@ -49,6 +49,7 @@ class BidsDataset(mt_datasets.MRI2DSegmentationDataset):
                  canonical=True, labeled=True, roi_suffix=None, multichannel=False, missing_modality=False):
 
         self.bids_ds = bids.BIDS(root_dir)
+
         self.filename_pairs = []
         if metadata_choice == 'mri_params':
             self.metadata = {"FlipAngle": [], "RepetitionTime": [],
@@ -82,7 +83,6 @@ class BidsDataset(mt_datasets.MRI2DSegmentationDataset):
 
         for subject in tqdm(bids_subjects, desc="Loading dataset"):
             if subject.record["modality"] in contrast_lst:
-
                 # Training & Validation: do not consider the contrasts over the threshold contained in contrast_balance
                 if subject.record["modality"] in contrast_balance.keys():
                     c[subject.record["modality"]] = c[subject.record["modality"]] + 1

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -653,7 +653,7 @@ def cmd_test(context):
             with torch.no_grad():
                 if cuda_available:
                     test_input = utils.cuda(input_samples)
-                    test_gt = gt_samples.cuda(non_blocking=True)
+                    test_gt = utils.cuda(gt_samples)
                 else:
                     test_input = input_samples
                     test_gt = gt_samples

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -724,7 +724,8 @@ def cmd_test(context):
                                                        kernel_dim='2d',
                                                        bin_thr=0.5 if context["binarize_prediction"] else -1)
 
-                        if output_nii.get_data().shape[-1] > 1:
+                        output_nii_shape = output_nii.get_data().shape
+                        if len(output_nii_shape) == 4 and output_nii_shape[-1] > 1:
                             utils.save_color_labels(output_nii.get_data(),
                                                     context["binarize_prediction"],
                                                     fname_tmp,
@@ -757,7 +758,8 @@ def cmd_test(context):
                                                    bin_thr=0.5 if context["binarize_prediction"] else -1)
 
                     # Save merged labels with color
-                    if output_nii.shape[-1] > 1:
+                    output_nii_shape = output_nii.get_data().shape
+                    if len(output_nii_shape) == 4 and output_nii_shape[-1] > 1:
                         utils.save_color_labels(output_nii.get_data(),
                                                 context['binarize_prediction'],
                                                 rdict_undo['input_metadata']['gt_filenames'][0],

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -866,10 +866,19 @@ def cmd_eval(context):
                                 subj_acq + context['target_suffix'] + '.nii.gz')
 
         # 3D evaluation
-        eval = Evaluation3DMetrics(fname_pred=fname_pred,
-                                   fname_gt=fname_gt,
+        nib_gt, nib_pred = nib.load(fname_gt), nib.load(fname_pred)
+        data_gt, data_pred = nib_gt.get_data(), nib_pred.get_data()
+        eval = Evaluation3DMetrics(data_pred=data_pred,
+                                   data_gt=data_gt,
+                                   dim_lst=nib_gt.header['pixdim'][1:4],
                                    params=context['eval_params'])
-        results_pred = eval.run_eval()
+        # run eval
+        results_pred, data_painted = eval.run_eval()
+        # save painted data, TP FP FN
+        fname_paint = fname_pred.split('.nii.gz')[0] + '_painted.nii.gz'
+        nib_painted = nib.Nifti1Image(data_painted, nib_pred.affine)
+        nib.save(nib_painted, fname_paint)
+
         # save results of this fname_pred
         results_pred['image_id'] = subj_acq
         df_results = df_results.append(results_pred, ignore_index=True)

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -201,12 +201,20 @@ def cmd_train(context):
         for param in model.parameters():
             param.requires_grad = False
 
+        # TMP
+        model.decoder = models.Decoder(out_channel=context['out_channel'],
+                                        depth=context['depth'],
+                                        n_metadata=n_metadata,
+                                        film_layers=[0] * (2 * context['depth'] + 2),
+                                        drop_rate=context["dropout_rate"],
+                                        bn_momentum=context["batch_norm_momentum"])
+
         # Replace the last conv layer
         # Note: Parameters of newly constructed layer have requires_grad=True by default
-        model.decoder.last_conv = nn.Conv2d(model.decoder.last_conv.in_channels,
-                                            context['out_channel'], kernel_size=3, padding=1)
-        if film_bool and context["film_layers"][-1]:
-            model.decoder.last_film = models.FiLMlayer(n_metadata, 1)
+        #model.decoder.last_conv = nn.Conv2d(model.decoder.last_conv.in_channels,
+        #                                    context['out_channel'], kernel_size=3, padding=1)
+        #if film_bool and context["film_layers"][-1]:
+        #    model.decoder.last_film = models.FiLMlayer(n_metadata, 1)
 
     if cuda_available:
         model.cuda()

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -675,7 +675,7 @@ def cmd_test(context):
     metric_mgr = IvadoMetricManager(metric_fns)
 
     # number of Monte Carlo simulation
-    if (context['uncertainty']['epistemic'] or context['uncertainty']['epistemic']) and \
+    if (context['uncertainty']['epistemic'] or context['uncertainty']['aleatoric']) and \
             context['uncertainty']['n_it'] > 0:
         n_monteCarlo = context['uncertainty']['n_it']
     else:

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -653,7 +653,7 @@ def cmd_test(context):
             with torch.no_grad():
                 if cuda_available:
                     test_input = utils.cuda(input_samples)
-                    test_gt = utils.cuda(gt_samples)
+                    test_gt = gt_samples.cuda(non_blocking=True)
                 else:
                     test_input = input_samples
                     test_gt = gt_samples

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -12,11 +12,11 @@ import pandas as pd
 import torch
 import torch.backends.cudnn as cudnn
 import torch.nn as nn
-from ivadomed import loader as loader
+from ivadomed import loader as imed_loader
 from ivadomed import losses
 from ivadomed import metrics
 from ivadomed import models
-from ivadomed import utils
+from ivadomed import utils as imed_utils
 from medicaltorch import datasets as mt_datasets
 from torch import optim
 from torch.utils.data import DataLoader
@@ -88,7 +88,7 @@ def cmd_train(context):
 
     # Randomly split dataset between training / validation / testing
     if context.get("split_path") is None:
-        train_lst, valid_lst, test_lst = loader.split_dataset(path_folder=context["bids_path"],
+        train_lst, valid_lst, test_lst = imed_loader.split_dataset(path_folder=context["bids_path"],
                                                               center_test_lst=context["center_test"],
                                                               split_method=context["split_method"],
                                                               random_seed=context["random_seed"],
@@ -105,19 +105,19 @@ def cmd_train(context):
 
     # This code will iterate over the folders and load the data, filtering
     # the slices without labels and then concatenating all the datasets together
-    ds_train = loader.load_dataset(train_lst, train_transform, context)
+    ds_train = imed_loader.load_dataset(train_lst, train_transform, context)
 
     # if ROICrop2D in transform, then apply SliceFilter to ROI slices
     if 'ROICrop2D' in context["transformation_training"].keys():
-        ds_train = loader.filter_roi(ds_train, nb_nonzero_thr=context["slice_filter_roi"])
+        ds_train = imed_loader.filter_roi(ds_train, nb_nonzero_thr=context["slice_filter_roi"])
 
     if film_bool:  # normalize metadata before sending to the network
         if context["metadata"] == "mri_params":
             metadata_vector = ["RepetitionTime", "EchoTime", "FlipAngle"]
-            metadata_clustering_models = loader.clustering_fit(ds_train.metadata, metadata_vector)
+            metadata_clustering_models = imed_loader.clustering_fit(ds_train.metadata, metadata_vector)
         else:
             metadata_clustering_models = None
-        ds_train, train_onehotencoder = loader.normalize_metadata(ds_train,
+        ds_train, train_onehotencoder = imed_loader.normalize_metadata(ds_train,
                                                                   metadata_clustering_models,
                                                                   context["debugging"],
                                                                   context["metadata"],
@@ -130,7 +130,7 @@ def cmd_train(context):
             f"Loaded {len(ds_train)} volumes of size {context['length_3D']} for the training set.")
 
     if context['balance_samples']:
-        sampler_train = loader.BalancedSampler(ds_train)
+        sampler_train = imed_loader.BalancedSampler(ds_train)
         shuffle_train = False
     else:
         sampler_train, shuffle_train = None, True
@@ -141,14 +141,14 @@ def cmd_train(context):
                               num_workers=0)
 
     # Validation dataset ------------------------------------------------------
-    ds_val = loader.load_dataset(valid_lst, val_transform, context)
+    ds_val = imed_loader.load_dataset(valid_lst, val_transform, context)
 
     # if ROICrop2D in transform, then apply SliceFilter to ROI slices
     if 'ROICrop2D' in context["transformation_validation"].keys():
-        ds_val = loader.filter_roi(ds_val, nb_nonzero_thr=context["slice_filter_roi"])
+        ds_val = imed_loader.filter_roi(ds_val, nb_nonzero_thr=context["slice_filter_roi"])
 
     if film_bool:  # normalize metadata before sending to network
-        ds_val = loader.normalize_metadata(ds_val,
+        ds_val = imed_loader.normalize_metadata(ds_val,
                                            metadata_clustering_models,
                                            context["debugging"],
                                            context["metadata"],
@@ -161,7 +161,7 @@ def cmd_train(context):
             f"Loaded {len(ds_val)} volumes of size {context['length_3D']} for the validation set.")
 
     if context['balance_samples']:
-        sampler_val = loader.BalancedSampler(ds_val)
+        sampler_val = imed_loader.BalancedSampler(ds_val)
         shuffle_val = False
     else:
         sampler_val, shuffle_val = None, True
@@ -445,7 +445,7 @@ def cmd_train(context):
 
             preds_npy = preds.data.cpu().numpy()
             if context["binarize_prediction"]:
-                preds_npy = utils.threshold_predictions(preds_npy)
+                preds_npy = imed_utils.threshold_predictions(preds_npy)
             preds_npy = preds_npy.astype(np.uint8)
 
             metric_mgr(preds_npy, gt_npy)
@@ -454,7 +454,7 @@ def cmd_train(context):
 
             # Only write sample at the first step
             if i == 0:
-                utils.save_tensorboard_img(writer, epoch, "Validation", input_samples, gt_samples, preds, unet_3D)
+                imed_utils.save_tensorboard_img(writer, epoch, "Validation", input_samples, gt_samples, preds, unet_3D)
 
             # Store the values of gammas and betas after the last epoch for each batch
             if film_bool and epoch == num_epochs and i < int(len(ds_val) / context["batch_size"]) + 1:
@@ -583,16 +583,16 @@ def cmd_test(context):
     else:
         test_lst = joblib.load(context["split_path"])['test']
 
-    ds_test = loader.load_dataset(test_lst, val_transform, context)
+    ds_test = imed_loader.load_dataset(test_lst, val_transform, context)
 
     # if ROICrop2D in transform, then apply SliceFilter to ROI slices
     if 'ROICrop2D' in context["transformation_validation"].keys():
-        ds_test = loader.filter_roi(ds_test, nb_nonzero_thr=context["slice_filter_roi"])
+        ds_test = imed_loader.filter_roi(ds_test, nb_nonzero_thr=context["slice_filter_roi"])
 
     if film_bool:  # normalize metadata before sending to network
         metadata_clustering_models = joblib.load(
             "./" + context["log_directory"] + "/clustering_models.joblib")
-        ds_test = loader.normalize_metadata(ds_test,
+        ds_test = imed_loader.normalize_metadata(ds_test,
                                             metadata_clustering_models,
                                             context["debugging"],
                                             context["metadata"],
@@ -652,7 +652,7 @@ def cmd_test(context):
 
             with torch.no_grad():
                 if cuda_available:
-                    test_input = utils.cuda(input_samples)
+                    test_input = imed_utils.cuda(input_samples)
                     test_gt = gt_samples.cuda(non_blocking=True)
                 else:
                     test_input = input_samples
@@ -676,8 +676,8 @@ def cmd_test(context):
                 else:
                     preds = model(test_input)
                     if context["attention_unet"]:
-                        utils.save_feature_map(batch, "attentionblock2", context, model, test_input,
-                                               utils.AXIS_DCT[context["slice_axis"]])
+                        imed_utils.save_feature_map(batch, "attentionblock2", context, model, test_input,
+                                               imed_utils.AXIS_DCT[context["slice_axis"]])
 
             # WARNING: sample['gt'] is actually the pred in the return sample
             # implementation justification: the other option: rdict['pred'] = preds would require to largely modify mt_transforms
@@ -716,27 +716,27 @@ def cmd_test(context):
                         if n_monteCarlo > 1:
                             fname_pred = fname_pred.split('.nii.gz')[0] + '_' + str(i_monteCarlo).zfill(2) + '.nii.gz'
 
-                        output_nii = utils.pred_to_nib(data_lst=pred_tmp_lst,
-                                                       z_lst=z_tmp_lst,
-                                                       fname_ref=fname_tmp,
-                                                       fname_out=fname_pred,
-                                                       slice_axis=utils.AXIS_DCT[context['slice_axis']],
-                                                       kernel_dim='2d',
-                                                       bin_thr=0.5 if context["binarize_prediction"] else -1)
+                        output_nii = imed_utils.pred_to_nib(data_lst=pred_tmp_lst,
+                                                               z_lst=z_tmp_lst,
+                                                               fname_ref=fname_tmp,
+                                                               fname_out=fname_pred,
+                                                               slice_axis=utils.AXIS_DCT[context['slice_axis']],
+                                                               kernel_dim='2d',
+                                                               bin_thr=0.5 if context["binarize_prediction"] else -1)
 
                         output_nii_shape = output_nii.get_data().shape
                         if len(output_nii_shape) == 4 and output_nii_shape[-1] > 1:
-                            utils.save_color_labels(output_nii.get_data(),
-                                                    context["binarize_prediction"],
-                                                    fname_tmp,
-                                                    fname_pred.split(".nii.gz")[0] + '_color.nii.gz',
-                                                    utils.AXIS_DCT[context['slice_axis']])
+                            imed_utils.save_color_labels(output_nii.get_data(),
+                                                            context["binarize_prediction"],
+                                                            fname_tmp,
+                                                            fname_pred.split(".nii.gz")[0] + '_color.nii.gz',
+                                                            imed_utils.AXIS_DCT[context['slice_axis']])
 
                         # re-init pred_stack_lst
                         pred_tmp_lst, z_tmp_lst = [], []
 
                     # add new sample to pred_tmp_lst
-                    pred_tmp_lst.append(utils.pil_list_to_numpy(rdict_undo['gt']))
+                    pred_tmp_lst.append(imed_utils.pil_list_to_numpy(rdict_undo['gt']))
                     z_tmp_lst.append(int(rdict_undo['input_metadata']['slice_index']))
                     fname_tmp = fname_ref
 
@@ -749,29 +749,29 @@ def cmd_test(context):
                         fname_pred = fname_pred.split('.nii.gz')[0] + '_' + str(i_monteCarlo).zfill(2) + '.nii.gz'
 
                     # Choose only one modality
-                    output_nii = utils.pred_to_nib(data_lst=rdict_undo['gt'].transpose((2, 3, 1, 0)),
-                                                   z_lst=[],
-                                                   fname_ref=fname_ref,
-                                                   fname_out=fname_pred,
-                                                   slice_axis=utils.AXIS_DCT[context['slice_axis']],
-                                                   kernel_dim='3d',
-                                                   bin_thr=0.5 if context["binarize_prediction"] else -1)
+                    output_nii = imed_utils.pred_to_nib(data_lst=rdict_undo['gt'].transpose((2, 3, 1, 0)),
+                                                           z_lst=[],
+                                                           fname_ref=fname_ref,
+                                                           fname_out=fname_pred,
+                                                           slice_axis=imed_utils.AXIS_DCT[context['slice_axis']],
+                                                           kernel_dim='3d',
+                                                           bin_thr=0.5 if context["binarize_prediction"] else -1)
 
                     # Save merged labels with color
                     output_nii_shape = output_nii.get_data().shape
                     if len(output_nii_shape) == 4 and output_nii_shape[-1] > 1:
-                        utils.save_color_labels(output_nii.get_data(),
-                                                context['binarize_prediction'],
-                                                rdict_undo['input_metadata']['gt_filenames'][0],
-                                                fname_pred.split(".nii.gz")[0] + '_color.nii.gz',
-                                                utils.AXIS_DCT[context['slice_axis']])
+                        imed_utils.save_color_labels(output_nii.get_data(),
+                                                        context['binarize_prediction'],
+                                                        rdict_undo['input_metadata']['gt_filenames'][0],
+                                                        fname_pred.split(".nii.gz")[0] + '_color.nii.gz',
+                                                        imed_utils.AXIS_DCT[context['slice_axis']])
 
             # Metrics computation
             gt_npy = gt_samples.numpy().astype(np.uint8)
 
             preds_npy = preds.data.cpu().numpy()
             if context["binarize_prediction"]:
-                preds_npy = utils.threshold_predictions(preds_npy)
+                preds_npy = imed_utils.threshold_predictions(preds_npy)
             preds_npy = preds_npy.astype(np.uint8)
 
             metric_mgr(preds_npy, gt_npy)
@@ -779,7 +779,7 @@ def cmd_test(context):
     # COMPUTE UNCERTAINTY MAPS
     if (context['uncertainty']['epistemic'] or context['uncertainty']['aleatoric']) and context['uncertainty'][
         'n_it'] > 0:
-        utils.run_uncertainty(ifolder=path_3Dpred)
+        imed_utils.run_uncertainty(ifolder=path_3Dpred)
 
     metrics_dict = metric_mgr.get_results()
     metric_mgr.reset()
@@ -833,10 +833,10 @@ def cmd_eval(context):
             else:
                 data_gt[..., idx] = np.zeros((h, w, d), dtype='u1')
 
-        eval = Evaluation3DMetrics(data_pred=data_pred,
-                                   data_gt=data_gt,
-                                   dim_lst=nib_pred.header['pixdim'][1:4],
-                                   params=context['eval_params'])
+        eval = imed_utils.Evaluation3DMetrics(data_pred=data_pred,
+                                               data_gt=data_gt,
+                                               dim_lst=nib_pred.header['pixdim'][1:4],
+                                               params=context['eval_params'])
 
         # run eval
         results_pred, data_painted = eval.run_eval()

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -116,7 +116,7 @@ class Evaluation3DMetrics(object):
 
             if n_nonzero < self.size_min:
                 data[data_label == idx] = 0
-        print(data.shape)
+
         return data
 
     def _get_size_ranges(self, thr_lst, unit):

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -331,6 +331,8 @@ def pred_to_nib(data_lst, z_lst, fname_ref, fname_out, slice_axis, debug=False, 
 
     if bin_thr >= 0:
         arr_pred_ref_space = threshold_predictions(arr_pred_ref_space, thr=bin_thr)
+    else: # discard noise
+        arr_pred_ref_space[arr_pred_ref_space <= 1e-3] = 0
 
     # create nibabel object
     nib_pred = nib.Nifti1Image(arr_pred_ref_space, nib_ref.affine)

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -33,7 +33,13 @@ class Evaluation3DMetrics(object):
     def __init__(self, data_pred, data_gt, dim_lst, params={}):
 
         self.data_pred = data_pred
+        if len(self.data_pred) == 3:
+            self.data_pred = np.expand_dims(self.data_pred, -1)
+
         self.data_gt = data_gt
+        if len(self.data_gt) == 3:
+            self.data_gt = np.expand_dims(self.data_gt, -1)
+
         self.n_classes = data_gt.shape[-1]
 
         self.px, self.py, self.pz = dim_lst
@@ -102,6 +108,7 @@ class Evaluation3DMetrics(object):
             self.overlap_vox = 3
 
     def remove_small_objects(self, data):
+        print(data.shape, self.bin_struct)
         data_label, n = label(data,
                               structure=self.bin_struct)
 
@@ -295,6 +302,9 @@ class Evaluation3DMetrics(object):
                                                                                                   class_idx=n)
                 else:  # gt_pred == 'pred'
                     dct['lfdr' + suffix + "_class" + str(n)] = self.get_lfdr(label_size=lb_size, class_idx=n)
+
+        if self.n_classes == 1:
+            self.data_painted = np.squeeze(self.data_painted, axis=-1)
 
         return dct, self.data_painted
 

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -1,25 +1,25 @@
 import os
 import json
 from collections import defaultdict
-
+from scipy.ndimage import label, generate_binary_structure
 import matplotlib.pyplot as plt
 import nibabel as nib
 import numpy as np
+from tqdm import tqdm
+
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 import torch.nn.functional as F
+from torch.autograd import Variable
+import torchvision.utils as vutils
 
 from ivadomed import loader as ivadomed_loader
 from ivadomed import transforms as ivadomed_transforms
-from medicaltorch.datasets import MRI2DSegmentationDataset
 from ivadomed import metrics
-from medicaltorch import datasets as mt_datasets
 
-from scipy.ndimage import label, generate_binary_structure
-from torch.autograd import Variable
-from tqdm import tqdm
-import torchvision.utils as vutils
+from medicaltorch.datasets import MRI2DSegmentationDataset
+from medicaltorch import datasets as mt_datasets
 
 # labels of paint_objects method
 TP_COLOUR = 1

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -14,9 +14,9 @@ import torch.nn.functional as F
 from torch.autograd import Variable
 import torchvision.utils as vutils
 
-from ivadomed import loader as ivadomed_loader
-from ivadomed import transforms as ivadomed_transforms
-from ivadomed import metrics
+from ivadomed import loader as imed_loader
+from ivadomed import transforms as imed_transforms
+from ivadomed import metrics as imed_metrics
 
 from medicaltorch.datasets import MRI2DSegmentationDataset
 from medicaltorch import datasets as mt_datasets
@@ -284,10 +284,10 @@ class Evaluation3DMetrics(object):
             dct['vol_pred_class' + str(n)] = self.get_vol(self.data_pred)
             dct['vol_gt_class' + str(n)] = self.get_vol(self.data_gt)
             dct['rvd_class' + str(n)], dct['avd_class' + str(n)] = self.get_rvd(), self.get_avd()
-            dct['dice_class' + str(n)] = dice_score(self.data_gt[..., n], self.data_pred[..., n]) * 100.
-            dct['recall_class' + str(n)] = mt_metrics.recall_score(self.data_pred, self.data_gt, err_value=np.nan)
-            dct['precision_class' + str(n)] = mt_metrics.precision_score(self.data_pred, self.data_gt, err_value=np.nan)
-            dct['specificity_class' + str(n)] = mt_metrics.specificity_score(self.data_pred, self.data_gt, err_value=np.nan)
+            dct['dice_class' + str(n)] = imed_metrics.dice_score(self.data_gt[..., n], self.data_pred[..., n]) * 100.
+            dct['recall_class' + str(n)] = imed_metrics.recall_score(self.data_pred, self.data_gt, err_value=np.nan)
+            dct['precision_class' + str(n)] = imed_metrics.precision_score(self.data_pred, self.data_gt, err_value=np.nan)
+            dct['specificity_class' + str(n)] = imed_metrics.specificity_score(self.data_pred, self.data_gt, err_value=np.nan)
             dct['n_pred_class' + str(n)], dct['n_gt_class' + str(n)] = self.n_pred[n], self.n_gt[n]
             dct['ltpr_class' + str(n)], _ = self.get_ltpr()
             dct['lfdr_class' + str(n)] = self.get_lfdr()
@@ -646,10 +646,10 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
                                                     for (key, value) in context["transformation_validation"].items())
 
     # Compose transforms
-    do_transforms = ivadomed_transforms.compose_transforms(context['transformation_validation'])
+    do_transforms = imed_transforms.compose_transforms(context['transformation_validation'])
 
     # Undo Transforms
-    undo_transforms = ivadomed_transforms.UndoCompose(do_transforms)
+    undo_transforms = imed_transforms.UndoCompose(do_transforms)
 
     # Force filter_empty_mask to False if fname_roi = None
     if fname_roi is None and 'filter_empty_mask' in context["slice_filter"]:
@@ -670,7 +670,7 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
 
     # If fname_roi provided, then remove slices without ROI
     if fname_roi is not None:
-        ds = ivadomed_loader.filter_roi(ds, nb_nonzero_thr=context["slice_filter_roi"])
+        ds = imed_loader.filter_roi(ds, nb_nonzero_thr=context["slice_filter_roi"])
 
     if not context['unet_3D']:
         print(f"\nLoaded {len(ds)} {context['slice_axis']} slices..")

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -43,14 +43,12 @@ class IvadoMetricManager(mt_metrics.MetricManager):
 
 class Evaluation3DMetrics(object):
 
-    def __init__(self, fname_pred, fname_gt, params={}):
-        self.fname_pred = fname_pred
-        self.fname_gt = fname_gt
+    def __init__(self, data_pred, data_gt, dim_lst, params={}):
 
-        self.data_pred = self.get_data(self.fname_pred)
-        self.data_gt = self.get_data(self.fname_gt)
+        self.data_pred = data_pred
+        self.data_gt = data_gt
 
-        self.px, self.py, self.pz = self.get_pixdim(self.fname_pred)
+        self.px, self.py, self.pz = dim_lst
 
         self.bin_struct = generate_binary_structure(3, 2)  # 18-connectivity
 
@@ -92,7 +90,6 @@ class Evaluation3DMetrics(object):
                                               structure=self.bin_struct)
 
         # painted data, object wise
-        self.fname_paint = fname_pred.split('.nii.gz')[0] + '_painted.nii.gz'
         self.data_painted = np.copy(self.data_pred)
 
         # overlap_vox is used to define the object-wise TP, FP, FN
@@ -106,15 +103,6 @@ class Evaluation3DMetrics(object):
                 self.overlap_vox = None
         else:
             self.overlap_vox = 3
-
-    def get_data(self, fname):
-        nib_im = nib.load(fname)
-        return nib_im.get_data()
-
-    def get_pixdim(self, fname):
-        nib_im = nib.load(fname)
-        px, py, pz = nib_im.header['pixdim'][1:4]
-        return px, py, pz
 
     def remove_small_objects(self, data):
         data_label, n = label(data,
@@ -306,11 +294,7 @@ class Evaluation3DMetrics(object):
             else:  # gt_pred == 'pred'
                 dct['lfdr' + suffix] = self.get_lfdr(label_size=lb_size)
 
-        # save painted file
-        nib_painted = nib.Nifti1Image(self.data_painted, nib.load(self.fname_pred).affine)
-        nib.save(nib_painted, self.fname_paint)
-
-        return dct
+        return dct, self.data_painted
 
 
 def save_nii(data_lst, z_lst, fname_ref, fname_out, slice_axis, debug=False, unet_3D=False, binarize=True):

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -33,15 +33,14 @@ class Evaluation3DMetrics(object):
     def __init__(self, data_pred, data_gt, dim_lst, params={}):
 
         self.data_pred = data_pred
-        if len(self.data_pred) == 3:
+        if len(self.data_pred.shape) == 3:
             self.data_pred = np.expand_dims(self.data_pred, -1)
 
         self.data_gt = data_gt
-        if len(self.data_gt) == 3:
+        if len(self.data_gt.shape) == 3:
             self.data_gt = np.expand_dims(self.data_gt, -1)
 
-        self.n_classes = data_gt.shape[-1]
-
+        h, w, d, self.n_classes = self.data_gt.shape
         self.px, self.py, self.pz = dim_lst
 
         self.bin_struct = generate_binary_structure(3, 2)  # 18-connectivity
@@ -108,7 +107,6 @@ class Evaluation3DMetrics(object):
             self.overlap_vox = 3
 
     def remove_small_objects(self, data):
-        print(data.shape, self.bin_struct)
         data_label, n = label(data,
                               structure=self.bin_struct)
 
@@ -118,7 +116,7 @@ class Evaluation3DMetrics(object):
 
             if n_nonzero < self.size_min:
                 data[data_label == idx] = 0
-
+        print(data.shape)
         return data
 
     def _get_size_ranges(self, thr_lst, unit):


### PR DESCRIPTION
### General idea:
To use the uncertainty information to perform a voxel-wise or a lesion-wise filtering in post-processing.
Based on [Nair et al. 2020 work](https://www.sciencedirect.com/science/article/pii/S1361841519300994#sec0010).

### Dev script:
The script `dev/filtering_lesion.py` computes the voxel-level perforamance ROC curves that compare performance on the retained predictions for the different uncertainty measures at three different uncertainty thresholds (0.01, 0.1 and 0.5).
Predictions below the uncertainty threshold are used to calculate performance metrics (TPR and FDR) for different thresholds on the prediction masks (i.e. sigmoid threshold used to binarize the network’s predictions is varied).
**Hypothesis:** If the predictions that are incorrect are uncertain, this filtering should increase the performance on remaining predictions.
TPR being defined by TP / (TP+FN). FDR by FP / (FP + TP).

Also Done:
- `dev/filtering_lesion.py`: compute percentage of voxels / lesion retained after uncertainty-filtering.