### PR TITLE
Fix cmd_test always using gpu 0

### DIFF
--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -610,7 +610,7 @@ def cmd_train(context):
 
 def cmd_test(context):
     ##### DEFINE DEVICE #####
-    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:" + str(context['gpu']) if torch.cuda.is_available() else "cpu")
     cuda_available = torch.cuda.is_available()
     if not cuda_available:
         print("cuda is not available.")


### PR DESCRIPTION
GPU 0 was hard-coded for `cmd_test` which is problematic when trying to run simultaneous inferences. 