### PR TITLE
Merge medicaltorch into ivadomed 1 of 3

### DIFF
--- a/dev/class_balance.py
+++ b/dev/class_balance.py
@@ -10,7 +10,6 @@
 #
 ##############################################################
 
-import os
 import json
 import argparse
 import numpy as np

--- a/dev/data_aug_dilation.py
+++ b/dev/data_aug_dilation.py
@@ -4,7 +4,6 @@
 # Example: python data_aug_dilation.py t2_seg.nii.gz
 #
 
-import os
 import sys
 import numpy as np
 import random

--- a/dev/metadata_config.py
+++ b/dev/metadata_config.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 from torchvision import transforms
 
 from ivadomed import loader as loader
-from ivadomed.main import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import transforms as mt_transforms
 
 

--- a/dev/plot_cluster_metadata.py
+++ b/dev/plot_cluster_metadata.py
@@ -7,8 +7,6 @@ import sys
 import os
 import json
 import numpy as np
-from tqdm import tqdm
-from itertools import groupby
 from torchvision import transforms
 import matplotlib.pyplot as plt
 from sklearn.externals import joblib

--- a/dev/plot_cluster_metadata.py
+++ b/dev/plot_cluster_metadata.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 from sklearn.externals import joblib
 
 from ivadomed import loader as loader
-from ivadomed.main import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import transforms as mt_transforms
 
 metadata_type = ['FlipAngle', 'EchoTime', 'RepetitionTime']

--- a/ivadomed/loader.py
+++ b/ivadomed/loader.py
@@ -1,7 +1,6 @@
 from bids_neuropoly import bids
 from medicaltorch import datasets as mt_datasets
 from ivadomed.utils import SliceFilter
-from ivadomed.utils import *
 
 from sklearn.preprocessing import OneHotEncoder
 from scipy.signal import argrelextrema
@@ -11,11 +10,8 @@ from sklearn.model_selection import train_test_split
 
 import numpy as np
 import json
-from PIL import Image
-from glob import glob
 from copy import deepcopy
 from tqdm import tqdm
-import nibabel as nib
 import torch
 
 with open("config/contrast_dct.json", "r") as fhandle:

--- a/ivadomed/loader.py
+++ b/ivadomed/loader.py
@@ -1,6 +1,6 @@
 from bids_neuropoly import bids
 from medicaltorch import datasets as mt_datasets
-from medicaltorch.filters import SliceFilter
+from ivadomed.utils import SliceFilter
 from ivadomed.utils import *
 
 from sklearn.preprocessing import OneHotEncoder

--- a/ivadomed/losses.py
+++ b/ivadomed/losses.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 
 def dice_loss(input, target):
@@ -90,4 +89,3 @@ class GeneralizedDiceLoss(nn.Module):
         denominator = ((input + target).sum(-1) * class_weights).sum()
 
         return 1. - 2. * intersect / denominator.clamp(min=self.epsilon)
-

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -19,6 +19,7 @@ import ivadomed.transforms as ivadomed_transforms
 from ivadomed import loader as loader
 from ivadomed import losses
 from ivadomed import models
+from ivadomed import metrics
 from ivadomed.utils import *
 
 cudnn.benchmark = True
@@ -322,13 +323,13 @@ def cmd_train(context):
     epsilon = context["early_stopping_epsilon"]
     val_losses = []
 
-    metric_fns = [dice_score,  # from ivadomed/utils.py
-                  hausdorff_score,  # from ivadomed/utils.py
-                  mt_metrics.precision_score,
-                  mt_metrics.recall_score,
-                  mt_metrics.specificity_score,
-                  mt_metrics.intersection_over_union,
-                  mt_metrics.accuracy_score]
+    metric_fns = [metrics.dice_score,
+                  metrics.hausdorff_score,
+                  metrics.precision_score,
+                  metrics.recall_score,
+                  metrics.specificity_score,
+                  metrics.intersection_over_union,
+                  metrics.accuracy_score]
 
     for epoch in tqdm(range(1, num_epochs + 1), desc="Training"):
         start_time = time.time()
@@ -700,13 +701,13 @@ def cmd_test(context):
     if not os.path.isdir(path_3Dpred):
         os.makedirs(path_3Dpred)
 
-    metric_fns = [dice_score,  # from ivadomed/utils.py
-                  hausdorff_score,  # from ivadomed/utils.py
-                  mt_metrics.precision_score,
-                  mt_metrics.recall_score,
-                  mt_metrics.specificity_score,
-                  mt_metrics.intersection_over_union,
-                  mt_metrics.accuracy_score]
+    metric_fns = [metrics.dice_score,
+                  metrics.hausdorff_score,
+                  metrics.precision_score,
+                  metrics.recall_score,
+                  metrics.specificity_score,
+                  metrics.intersection_over_union,
+                  metrics.accuracy_score]
 
     metric_mgr = IvadoMetricManager(metric_fns)
 

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -288,7 +288,7 @@ def cmd_train(context):
     val_losses = []
 
     metric_fns = [metrics.dice_score,
-                  metrics.hausdorff_score,
+                  metrics.hausdorff_3D_score,
                   metrics.precision_score,
                   metrics.recall_score,
                   metrics.specificity_score,
@@ -666,7 +666,7 @@ def cmd_test(context):
         os.makedirs(path_3Dpred)
 
     metric_fns = [metrics.dice_score,
-                  metrics.hausdorff_score,
+                  metrics.hausdorff_3D_score,
                   metrics.precision_score,
                   metrics.recall_score,
                   metrics.specificity_score,

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -1,8 +1,11 @@
 import json
+import numpy as np
+import os
 import random
 import shutil
 import sys
 import time
+import torch
 
 import joblib
 import pandas as pd
@@ -12,6 +15,7 @@ from medicaltorch import datasets as mt_datasets
 from torch import optim
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
+from tqdm import tqdm
 
 import ivadomed.transforms as ivadomed_transforms
 from ivadomed import loader as loader

--- a/ivadomed/metrics.py
+++ b/ivadomed/metrics.py
@@ -1,0 +1,128 @@
+from collections import defaultdict
+
+from scipy import spatial
+import numpy as np
+
+
+class MetricManager(object):
+    def __init__(self, metric_fns):
+        self.metric_fns = metric_fns
+        self.result_dict = defaultdict(float)
+        self.num_samples = 0
+
+    def __call__(self, prediction, ground_truth):
+        self.num_samples += len(prediction)
+        for metric_fn in self.metric_fns:
+            for p, gt in zip(prediction, ground_truth):
+                res = metric_fn(p, gt)
+                dict_key = metric_fn.__name__
+                self.result_dict[dict_key] += res
+
+    def get_results(self):
+        res_dict = {}
+        for key, val in self.result_dict.items():
+            res_dict[key] = val / self.num_samples
+        return res_dict
+
+    def reset(self):
+        self.num_samples = 0
+        self.result_dict = defaultdict(float)
+
+
+def numeric_score(prediction, groundtruth):
+    """Computation of statistical numerical scores:
+
+    * FP = False Positives
+    * FN = False Negatives
+    * TP = True Positives
+    * TN = True Negatives
+
+    return: tuple (FP, FN, TP, TN)
+    """
+    FP = np.float(np.sum((prediction == 1) & (groundtruth == 0)))
+    FN = np.float(np.sum((prediction == 0) & (groundtruth == 1)))
+    TP = np.float(np.sum((prediction == 1) & (groundtruth == 1)))
+    TN = np.float(np.sum((prediction == 0) & (groundtruth == 0)))
+    return FP, FN, TP, TN
+
+
+def dice_score(im1, im2):
+    """
+    Computes the Dice coefficient between im1 and im2.
+    """
+    im1 = np.asarray(im1).astype(np.bool)
+    im2 = np.asarray(im2).astype(np.bool)
+
+    if im1.shape != im2.shape:
+        raise ValueError("Shape mismatch: im1 and im2 must have the same shape.")
+
+    im_sum = im1.sum() + im2.sum()
+    if im_sum == 0:
+        return np.nan
+
+    intersection = np.logical_and(im1, im2)
+    return (2. * intersection.sum()) / im_sum
+
+
+def jaccard_score(prediction, groundtruth):
+    pflat = prediction.flatten()
+    gflat = groundtruth.flatten()
+    return (1 - spatial.distance.jaccard(pflat, gflat)) * 100.0
+
+
+def hausdorff_2D_score(prediction, groundtruth):
+    return spatial.distance.directed_hausdorff(prediction, groundtruth)[0]
+
+
+def hausdorff_3D_score(prediction, groundtruth):
+    if len(prediction.shape) == 3:
+        mean_hansdorff = 0
+        for idx in range(prediction.shape[1]):
+            pred = prediction[:, idx, :]
+            gt = groundtruth[:, idx, :]
+            mean_hansdorff += hausdorff_2D_score(pred, gt)
+        mean_hansdorff = mean_hansdorff / prediction.shape[1]
+        return mean_hansdorff
+
+    return hausdorff_2D_score(prediction, groundtruth)
+
+
+def precision_score(prediction, groundtruth, err_value=0.0):
+    # PPV
+    FP, FN, TP, TN = numeric_score(prediction, groundtruth)
+    if (TP + FP) <= 0.0:
+        return err_value
+
+    precision = np.divide(TP, TP + FP)
+    return precision * 100.0
+
+
+def recall_score(prediction, groundtruth, err_value=0.0):
+    # TPR, sensitivity
+    FP, FN, TP, TN = numeric_score(prediction, groundtruth)
+    if (TP + FN) <= 0.0:
+        return err_value
+    TPR = np.divide(TP, TP + FN)
+    return TPR * 100.0
+
+
+def specificity_score(prediction, groundtruth, err_value=0.0):
+    FP, FN, TP, TN = numeric_score(prediction, groundtruth)
+    if (TN + FP) <= 0.0:
+        return err_value
+    TNR = np.divide(TN, TN + FP)
+    return TNR * 100.0
+
+
+def intersection_over_union(prediction, groundtruth, err_value=0.0):
+    FP, FN, TP, TN = numeric_score(prediction, groundtruth)
+    if (TP + FP + FN) <= 0.0:
+        return err_value
+    return TP / (TP + FP + FN) * 100.0
+
+
+def accuracy_score(prediction, groundtruth):
+    FP, FN, TP, TN = numeric_score(prediction, groundtruth)
+    N = FP + FN + TP + TN
+    accuracy = np.divide(TP + TN, N)
+    return accuracy * 100.0

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -4,12 +4,9 @@ import numpy as np
 from PIL import Image
 import torchvision.transforms.functional as F
 from scipy.ndimage.measurements import label, center_of_mass
-from scipy.ndimage.morphology import binary_dilation, binary_fill_holes, binary_closing, generate_binary_structure
-import nibabel as nib
+from scipy.ndimage.morphology import binary_dilation, binary_fill_holes, binary_closing
 
 from medicaltorch import transforms as mt_transforms
-from scipy.ndimage.filters import gaussian_filter
-from scipy.ndimage.interpolation import map_coordinates
 
 
 def get_transform_names():
@@ -435,4 +432,3 @@ class ToTensor3D(mt_transforms.ToTensor):
 
         sample.update(rdict)
         return sample
-

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -14,7 +14,7 @@ from ivadomed import loader as ivadomed_loader
 from ivadomed import transforms as ivadomed_transforms
 from ivadomed.main import compose_transforms
 from medicaltorch.datasets import MRI2DSegmentationDataset
-from medicaltorch import metrics as mt_metrics
+from ivadomed import metrics
 from medicaltorch import datasets as mt_datasets
 
 from scipy.ndimage import label, generate_binary_structure
@@ -28,7 +28,8 @@ FN_COLOUR = 3
 
 AXIS_DCT = {'sagittal': 0, 'coronal': 1, 'axial': 2}
 
-class IvadoMetricManager(mt_metrics.MetricManager):
+
+class IvadoMetricManager(metrics.MetricManager):
     def __init__(self, metric_fns):
         super().__init__(metric_fns)
 
@@ -301,10 +302,10 @@ class Evaluation3DMetrics(object):
         dct['vol_pred'] = self.get_vol(self.data_pred)
         dct['vol_gt'] = self.get_vol(self.data_gt)
         dct['rvd'], dct['avd'] = self.get_rvd(), self.get_avd()
-        dct['dice'] = dice_score(self.data_gt, self.data_pred) * 100.
-        dct['recall'] = mt_metrics.recall_score(self.data_pred, self.data_gt, err_value=np.nan)
-        dct['precision'] = mt_metrics.precision_score(self.data_pred, self.data_gt, err_value=np.nan)
-        dct['specificity'] = mt_metrics.specificity_score(self.data_pred, self.data_gt, err_value=np.nan)
+        dct['dice'] = metrics.dice_score(self.data_gt, self.data_pred) * 100.
+        dct['recall'] = metrics.recall_score(self.data_pred, self.data_gt, err_value=np.nan)
+        dct['precision'] = metrics.precision_score(self.data_pred, self.data_gt, err_value=np.nan)
+        dct['specificity'] = metrics.specificity_score(self.data_pred, self.data_gt, err_value=np.nan)
         dct['n_pred'], dct['n_gt'] = self.n_pred, self.n_gt
         dct['ltpr'], _ = self.get_ltpr()
         dct['lfdr'] = self.get_lfdr()
@@ -558,37 +559,6 @@ def structureWise_uncertainty(fname_lst, fname_hard, fname_unc_vox, fname_out):
     nib.save(nib_iou, fname_iou)
     nib.save(nib_cv, fname_cv)
     nib.save(nib_avgUnc, fname_avgUnc)
-
-
-def dice_score(im1, im2):
-    """
-    Computes the Dice coefficient between im1 and im2.
-    """
-    im1 = np.asarray(im1).astype(np.bool)
-    im2 = np.asarray(im2).astype(np.bool)
-
-    if im1.shape != im2.shape:
-        raise ValueError("Shape mismatch: im1 and im2 must have the same shape.")
-
-    im_sum = im1.sum() + im2.sum()
-    if im_sum == 0:
-        return np.nan
-
-    intersection = np.logical_and(im1, im2)
-    return (2. * intersection.sum()) / im_sum
-
-
-def hausdorff_score(prediction, groundtruth):
-    if len(prediction.shape) == 3:
-        mean_hansdorff = 0
-        for idx in range(prediction.shape[1]):
-            pred = prediction[:, idx, :]
-            gt = groundtruth[:, idx, :]
-            mean_hansdorff += mt_metrics.hausdorff_score(pred, gt)
-        mean_hansdorff = mean_hansdorff / prediction.shape[1]
-        return mean_hansdorff
-
-    return mt_metrics.hausdorff_score(prediction, groundtruth)
 
 
 def mixup(data, targets, alpha):

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -880,3 +880,22 @@ def save_feature_map(batch, layer_name, context, model, test_input, slice_axis):
         nib_pred = nib.Nifti1Image(attention_map, nib_ref.affine)
 
         nib.save(nib_pred, save_directory)
+
+class SliceFilter(object):
+    def __init__(self, filter_empty_mask=True,
+                 filter_empty_input=True):
+        self.filter_empty_mask = filter_empty_mask
+        self.filter_empty_input = filter_empty_input
+
+    def __call__(self, sample):
+        input_data, gt_data = sample['input'], sample['gt']
+
+        if self.filter_empty_mask:
+            if not np.any(gt_data):
+                return False
+
+        if self.filter_empty_input:
+            if not np.all([np.any(img) for img in input_data]):
+                return False
+
+        return True

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -8,7 +8,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
-from torchvision import transforms
 import torch.nn.functional as F
 
 from ivadomed import loader as ivadomed_loader
@@ -16,9 +15,7 @@ from ivadomed import transforms as ivadomed_transforms
 from ivadomed.main import compose_transforms
 from medicaltorch.datasets import MRI2DSegmentationDataset
 from medicaltorch import metrics as mt_metrics
-from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
-from medicaltorch import transforms as mt_transforms
 
 from scipy.ndimage import label, generate_binary_structure
 from torch.autograd import Variable

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -16,7 +16,7 @@ from ivadomed import transforms as ivadomed_transforms
 from ivadomed.main import compose_transforms
 from medicaltorch.datasets import MRI2DSegmentationDataset
 from medicaltorch import metrics as mt_metrics
-from medicaltorch.filters import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
 from medicaltorch import transforms as mt_transforms
 
@@ -880,6 +880,7 @@ def save_feature_map(batch, layer_name, context, model, test_input, slice_axis):
         nib_pred = nib.Nifti1Image(attention_map, nib_ref.affine)
 
         nib.save(nib_pred, save_directory)
+
 
 class SliceFilter(object):
     def __init__(self, filter_empty_mask=True,

--- a/testing/test_HeMIS.py
+++ b/testing/test_HeMIS.py
@@ -15,7 +15,6 @@ from tqdm import tqdm
 from ivadomed import loader as loader
 from ivadomed import models
 from ivadomed import losses
-from ivadomed.utils import *
 import ivadomed.transforms as ivadomed_transforms
 
 cudnn.benchmark = True

--- a/testing/test_HeMIS.py
+++ b/testing/test_HeMIS.py
@@ -1,6 +1,5 @@
 import numpy as np
 import time
-import sys
 
 import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
@@ -71,8 +70,6 @@ def test_unet():
                              drop_rate=DROPOUT,
                              bn_momentum=BN)
 
-
-
     if cuda_available:
         model.cuda()
 
@@ -101,8 +98,7 @@ def test_unet():
             print("Batch = {}, {}".format(input_samples[0].shape, gt_samples.shape))
             print("rest of the function is not implemented yet")
             return 0
-            ## WIP - no train for now
-
+            # WIP - no train for now
 
             if cuda_available:
                 var_input = input_samples.cuda()
@@ -133,7 +129,7 @@ def test_unet():
             opt_lst.append(tot_opt)
 
             start_gen = time.time()
-    
+
         start_schedul = time.time()
         if not step_scheduler_batch:
             scheduler.step()
@@ -150,5 +146,6 @@ def test_unet():
     print('Mean SD opt {} --  {}'.format(np.mean(opt_lst), np.std(opt_lst)))
     print('Mean SD gen {} -- {}'.format(np.mean(gen_lst), np.std(gen_lst)))
     print('Mean SD scheduler {} -- {}'.format(np.mean(schedul_lst), np.std(schedul_lst)))
+
 
 test_unet()

--- a/testing/test_HeMIS.py
+++ b/testing/test_HeMIS.py
@@ -5,7 +5,7 @@ import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from medicaltorch.filters import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
 from medicaltorch import transforms as mt_transforms
 from torch import optim

--- a/testing/test_dilateGT.py
+++ b/testing/test_dilateGT.py
@@ -1,24 +1,16 @@
 import os
 import numpy as np
-import time
-import sys
 import matplotlib.pyplot as plt
 
 import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from medicaltorch.filters import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
-from medicaltorch import transforms as mt_transforms
-from torch import optim
-
-from tqdm import tqdm
 
 from ivadomed import loader as loader
-from ivadomed import models
-from ivadomed import losses
-from ivadomed.utils import *
+
 import ivadomed.transforms as ivadomed_transforms
 
 cudnn.benchmark = True
@@ -30,14 +22,14 @@ BN = 0.1
 N_EPOCHS = 10
 INIT_LR = 0.01
 PATH_BIDS = 'testing_data'
-#PATH_BIDS = os.path.join(.., 'duke', 'sct_testing', 'large')
+# PATH_BIDS = os.path.join(.., 'duke', 'sct_testing', 'large')
 PATH_OUT = 'tmp_test_dilateGT'
 
 
 def save_im_gt(im, gt, fname_out):
-    plt.figure(figsize=(20,10))
+    plt.figure(figsize=(20, 10))
 
-    i_zero, i_nonzero = np.where(gt==0.0), np.nonzero(gt)
+    i_zero, i_nonzero = np.where(gt == 0.0), np.nonzero(gt)
     img_jet = plt.cm.jet(plt.Normalize(vmin=0, vmax=1)(gt))
     img_jet[i_zero] = 0.0
     bkg_grey = plt.cm.binary_r(plt.Normalize(vmin=np.amin(im), vmax=np.amax(im))(im))
@@ -74,7 +66,8 @@ def test_dilateGT(dil_fac=0.25):
                                   subject_lst=train_lst,
                                   target_suffix="_lesion-manual",
                                   roi_suffix="_seg-manual",
-                                  contrast_lst=['T2w', 'acq-inf_T2star', 'acq-sup_T2star', 'acq-sup_T2w', 'acq-inf_T2w', 'acq-ax_T2w'],
+                                  contrast_lst=['T2w', 'acq-inf_T2star', 'acq-sup_T2star',
+                                                'acq-sup_T2w', 'acq-inf_T2w', 'acq-ax_T2w'],
                                   metadata_choice="without",
                                   contrast_balance={},
                                   slice_axis=2,
@@ -87,13 +80,14 @@ def test_dilateGT(dil_fac=0.25):
                               collate_fn=mt_datasets.mt_collate,
                               num_workers=1)
 
-    #if not os.path.isdir(PATH_OUT):
+    # if not os.path.isdir(PATH_OUT):
     #    os.makedirs(PATH_OUT)
 
     for i, batch in enumerate(train_loader):
         input_samples, gt_samples = batch["input"], batch["gt"]
         for b_idx in range(len(batch['input'])):
-            fname_out = os.path.join(PATH_OUT, 'im_'+str(i).zfill(2)+'_'+str(b_idx).zfill(2)+'.png')
+            fname_out = os.path.join(PATH_OUT, 'im_'+str(i).zfill(2) +
+                                     '_'+str(b_idx).zfill(2)+'.png')
      #       save_im_gt(np.array(input_samples[b_idx, 0]),
      #                   np.array(gt_samples[b_idx, 0]),
      #                   fname_out)

--- a/testing/test_inference.py
+++ b/testing/test_inference.py
@@ -91,7 +91,7 @@ def test_inference(film_bool=False):
     model.eval()
 
     metric_fns = [metrics.dice_score,  # from ivadomed/utils.py
-                  metrics.hausdorff_score,
+                  metrics.hausdorff_2D_score,
                   metrics.precision_score,
                   metrics.recall_score,
                   metrics.specificity_score,

--- a/testing/test_inference.py
+++ b/testing/test_inference.py
@@ -9,6 +9,7 @@ from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
 
 from ivadomed import loader as loader
+from ivadomed import metrics
 
 import ivadomed.transforms as ivadomed_transforms
 
@@ -89,13 +90,13 @@ def test_inference(film_bool=False):
         model.cuda()
     model.eval()
 
-    metric_fns = [dice_score,  # from ivadomed/utils.py
-                  mt_metrics.hausdorff_score,
-                  mt_metrics.precision_score,
-                  mt_metrics.recall_score,
-                  mt_metrics.specificity_score,
-                  mt_metrics.intersection_over_union,
-                  mt_metrics.accuracy_score]
+    metric_fns = [metrics.dice_score,  # from ivadomed/utils.py
+                  metrics.hausdorff_score,
+                  metrics.precision_score,
+                  metrics.recall_score,
+                  metrics.specificity_score,
+                  metrics.intersection_over_union,
+                  metrics.accuracy_score]
 
     metric_mgr = IvadoMetricManager(metric_fns)
 

--- a/testing/test_inference.py
+++ b/testing/test_inference.py
@@ -5,7 +5,7 @@ import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from medicaltorch.filters import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
 
 from ivadomed import loader as loader

--- a/testing/test_inference.py
+++ b/testing/test_inference.py
@@ -1,22 +1,15 @@
 import os
 import numpy as np
-import time
 
 import torch.backends.cudnn as cudnn
-from torch.utils.data import DataLoader, dataloader
+from torch.utils.data import DataLoader
 from torchvision import transforms
 
 from medicaltorch.filters import SliceFilter
 from medicaltorch import datasets as mt_datasets
-from medicaltorch import transforms as mt_transforms
-from torch import optim
-
-from tqdm import tqdm
 
 from ivadomed import loader as loader
-from ivadomed import models
-from ivadomed import losses
-from ivadomed.utils import *
+
 import ivadomed.transforms as ivadomed_transforms
 
 cudnn.benchmark = True
@@ -28,6 +21,7 @@ BN = 0.1
 SLICE_AXIS = 2
 PATH_BIDS = 'testing_data'
 PATH_OUT = 'tmp'
+
 
 def test_inference(film_bool=False):
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
@@ -55,17 +49,17 @@ def test_inference(film_bool=False):
     test_lst = ['sub-test001']
 
     ds_test = loader.BidsDataset(PATH_BIDS,
-                                  subject_lst=test_lst,
-                                  target_suffix="_lesion-manual",
-                                  roi_suffix="_seg-manual",
-                                  contrast_lst=['T2w', 'T2star'],
-                                  metadata_choice="contrast",
-                                  contrast_balance={},
-                                  slice_axis=SLICE_AXIS,
-                                  transform=val_transform,
-                                  multichannel=False,
-                                  slice_filter_fn=SliceFilter(filter_empty_input=True,
-                                                                filter_empty_mask=False))
+                                 subject_lst=test_lst,
+                                 target_suffix="_lesion-manual",
+                                 roi_suffix="_seg-manual",
+                                 contrast_lst=['T2w', 'T2star'],
+                                 metadata_choice="contrast",
+                                 contrast_balance={},
+                                 slice_axis=SLICE_AXIS,
+                                 transform=val_transform,
+                                 multichannel=False,
+                                 slice_filter_fn=SliceFilter(filter_empty_input=True,
+                                                             filter_empty_mask=False))
 
     ds_test = loader.filter_roi(ds_test, nb_nonzero_thr=10)
 
@@ -122,11 +116,13 @@ def test_inference(film_bool=False):
 
             if film_bool:
                 sample_metadata = batch["input_metadata"]
-                test_contrast = [sample_metadata[k]['contrast'] for k in range(len(sample_metadata))]
+                test_contrast = [sample_metadata[k]['contrast']
+                                 for k in range(len(sample_metadata))]
 
                 test_metadata = [one_hot_encoder.transform([sample_metadata[k]["film_input"]]).tolist()[0] for k in
                                  range(len(sample_metadata))]
-                preds = model(test_input, test_metadata)  # Input the metadata related to the input samples
+                # Input the metadata related to the input samples
+                preds = model(test_input, test_metadata)
             else:
                 preds = model(test_input)
 
@@ -145,7 +141,8 @@ def test_inference(film_bool=False):
             rdict_undo = val_undo_transform(rdict)
 
             fname_ref = rdict_undo['input_metadata']['gt_filename']
-            if pred_tmp_lst and (fname_ref != fname_tmp or (i == len(test_loader)-1 and smp_idx == len(batch['gt'])-1)):  # new processed file
+            # new processed file
+            if pred_tmp_lst and (fname_ref != fname_tmp or (i == len(test_loader)-1 and smp_idx == len(batch['gt'])-1)):
                 # save the completely processed file as a nii
                 fname_pred = os.path.join(PATH_OUT, fname_tmp.split('/')[-1])
                 fname_pred = fname_pred.split('manual.nii.gz')[0] + 'pred.nii.gz'
@@ -173,7 +170,8 @@ def test_inference(film_bool=False):
     metric_mgr.reset()
     print(metrics_dict)
 
+
 print("Test unet")
 test_inference()
 print("test unet-filmed")
-#test_inference(film_bool=True)
+# test_inference(film_bool=True)

--- a/testing/test_sampler.py
+++ b/testing/test_sampler.py
@@ -4,7 +4,7 @@ import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from medicaltorch.filters import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
 
 from ivadomed import loader as loader

--- a/testing/test_sampler.py
+++ b/testing/test_sampler.py
@@ -6,7 +6,6 @@ from torchvision import transforms
 
 from medicaltorch.filters import SliceFilter
 from medicaltorch import datasets as mt_datasets
-from medicaltorch import transforms as mt_transforms
 
 from ivadomed import loader as loader
 from ivadomed.utils import *
@@ -17,6 +16,7 @@ cudnn.benchmark = True
 GPU_NUMBER = 0
 BATCH_SIZE = 8
 PATH_BIDS = 'testing_data'
+
 
 def _cmpt_label(ds_loader):
     cmpt_label, cmpt_sample = {0: 0, 1: 0}, 0
@@ -32,7 +32,7 @@ def _cmpt_label(ds_loader):
     neg_sample_ratio = cmpt_label[0] * 100. / cmpt_sample
     pos_sample_ratio = cmpt_label[1] * 100. / cmpt_sample
     print({'neg_sample_ratio': neg_sample_ratio,
-            'pos_sample_ratio': pos_sample_ratio})
+           'pos_sample_ratio': pos_sample_ratio})
 
 
 def test_sampler():
@@ -73,10 +73,12 @@ def test_sampler():
 
     print('\nLoading with sampling')
     train_loader_balanced = DataLoader(ds_train, batch_size=BATCH_SIZE,
-                                          sampler=loader.BalancedSampler(ds_train),
-                                          shuffle=False, pin_memory=True,
-                                          collate_fn=mt_datasets.mt_collate,
-                                          num_workers=0)
+                                       sampler=loader.BalancedSampler(ds_train),
+                                       shuffle=False, pin_memory=True,
+                                       collate_fn=mt_datasets.mt_collate,
+                                       num_workers=0)
     _cmpt_label(train_loader_balanced)
+
+
 print("Test sampler")
 test_sampler()

--- a/testing/test_sampler.py
+++ b/testing/test_sampler.py
@@ -8,7 +8,6 @@ from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
 
 from ivadomed import loader as loader
-from ivadomed.utils import *
 import ivadomed.transforms as ivadomed_transforms
 
 cudnn.benchmark = True

--- a/testing/test_sliceFilter.py
+++ b/testing/test_sliceFilter.py
@@ -11,7 +11,6 @@ from medicaltorch import datasets as mt_datasets
 from medicaltorch import transforms as mt_transforms
 
 from ivadomed import loader as loader
-from ivadomed.utils import *
 import ivadomed.transforms as ivadomed_transforms
 
 cudnn.benchmark = True
@@ -19,6 +18,7 @@ cudnn.benchmark = True
 GPU_NUMBER = 0
 BATCH_SIZE = 8
 PATH_BIDS = 'testing_data'
+
 
 def _cmpt_slice(ds_loader, gt_roi='gt'):
     cmpt_label, cmpt_sample = {0: 0, 1: 0}, 0
@@ -31,6 +31,7 @@ def _cmpt_slice(ds_loader, gt_roi='gt'):
                 cmpt_label[0] += 1
             cmpt_sample += 1
     print(cmpt_label)
+
 
 def test_slice_filter_center():
     """Test SliceFilter when using mt_transforms.CenterCrop2D."""
@@ -68,9 +69,9 @@ def test_slice_filter_center():
 
         print('\tNumber of loaded slices: {}'.format(len(ds_train)))
         train_loader = DataLoader(ds_train, batch_size=BATCH_SIZE,
-                                      shuffle=True, pin_memory=True,
-                                      collate_fn=mt_datasets.mt_collate,
-                                      num_workers=0)
+                                  shuffle=True, pin_memory=True,
+                                  collate_fn=mt_datasets.mt_collate,
+                                  num_workers=0)
         print('\tNumber of Neg/Pos slices in GT.')
         _cmpt_slice(train_loader, 'gt')
 
@@ -114,13 +115,14 @@ def test_slice_filter_roi():
 
         print('\tNumber of loaded slices: {}'.format(len(ds_train)))
         train_loader = DataLoader(ds_train, batch_size=BATCH_SIZE,
-                                      shuffle=True, pin_memory=True,
-                                      collate_fn=mt_datasets.mt_collate,
-                                      num_workers=0)
+                                  shuffle=True, pin_memory=True,
+                                  collate_fn=mt_datasets.mt_collate,
+                                  num_workers=0)
         print('\tNumber of Neg/Pos slices in GT.')
         _cmpt_slice(train_loader, 'gt')
         print('\tNumber of Neg/Pos slices in ROI.')
         _cmpt_slice(train_loader, 'roi')
+
 
 print("Test test_slice_filter_center")
 test_slice_filter_center()

--- a/testing/test_sliceFilter.py
+++ b/testing/test_sliceFilter.py
@@ -6,7 +6,7 @@ import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from medicaltorch.filters import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
 from medicaltorch import transforms as mt_transforms
 

--- a/testing/test_training_time.py
+++ b/testing/test_training_time.py
@@ -15,7 +15,6 @@ from tqdm import tqdm
 from ivadomed import loader as loader
 from ivadomed import models
 from ivadomed import losses
-from ivadomed.utils import *
 import ivadomed.transforms as ivadomed_transforms
 
 cudnn.benchmark = True

--- a/testing/test_training_time.py
+++ b/testing/test_training_time.py
@@ -1,6 +1,5 @@
 import numpy as np
 import time
-import sys
 
 import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
@@ -65,7 +64,7 @@ def test_unet():
                                   transform=train_transform,
                                   multichannel=False,
                                   slice_filter_fn=SliceFilter(filter_empty_input=True, filter_empty_mask=False))
-    
+
     ds_mutichannel = loader.BidsDataset(PATH_BIDS,
                                         subject_lst=train_lst,
                                         target_suffix="_lesion-manual",
@@ -91,21 +90,20 @@ def test_unet():
                                  length=[96, 96, 16],
                                  padding=0)
 
-
     ds_train = loader.filter_roi(ds_train, nb_nonzero_thr=10)
 
     metadata_clustering_models = None
     ds_train, train_onehotencoder = loader.normalize_metadata(ds_train,
-                                                                metadata_clustering_models,
-                                                                False,
-                                                                "contrast",
-                                                                True)
+                                                              metadata_clustering_models,
+                                                              False,
+                                                              "contrast",
+                                                              True)
 
     train_loader = DataLoader(ds_train, batch_size=BATCH_SIZE,
                               shuffle=True, pin_memory=True,
                               collate_fn=mt_datasets.mt_collate,
                               num_workers=1)
-    
+
     multichannel_loader = DataLoader(ds_mutichannel, batch_size=BATCH_SIZE,
                                      shuffle=True, pin_memory=True,
                                      collate_fn=mt_datasets.mt_collate,
@@ -116,20 +114,21 @@ def test_unet():
                            num_workers=1)
 
     model_list = [(models.Unet(depth=DEPTH,
-                              film_layers=FILM_LAYERS,
-                              n_metadata=len([ll for l in train_onehotencoder.categories_ for ll in l]),
-                              drop_rate=DROPOUT,
-                              bn_momentum=BN,
-                              film_bool=True), train_loader, True, 'Filmed-Unet'),
+                               film_layers=FILM_LAYERS,
+                               n_metadata=len(
+                                   [ll for l in train_onehotencoder.categories_ for ll in l]),
+                               drop_rate=DROPOUT,
+                               bn_momentum=BN,
+                               film_bool=True), train_loader, True, 'Filmed-Unet'),
                   (models.Unet(in_channel=1,
-                              out_channel=1,
-                              depth=2,
-                              drop_rate=DROPOUT,
-                              bn_momentum=BN), train_loader, False, 'Unet'),
+                               out_channel=1,
+                               depth=2,
+                               drop_rate=DROPOUT,
+                               bn_momentum=BN), train_loader, False, 'Unet'),
                   (models.Unet(in_channel=2), multichannel_loader, False, 'Multi-Channels Unet'),
                   (models.UNet3D(in_channels=1, n_classes=1), loader_3d, False, '3D Unet'),
                   (models.UNet3D(in_channels=1, n_classes=1, attention=True), loader_3d, False, 'Attention UNet')]
-    
+
     for model, train_loader, film_bool, model_name in model_list:
         print("Training {}".format(model_name))
         if cuda_available:
@@ -173,7 +172,8 @@ def test_unet():
 
                 start_pred = time.time()
                 if film_bool:
-                    preds = model(var_input, var_metadata)  # Input the metadata related to the input samples
+                    # Input the metadata related to the input samples
+                    preds = model(var_input, var_metadata)
                 else:
                     preds = model(var_input)
                 tot_pred = time.time() - start_pred
@@ -211,5 +211,7 @@ def test_unet():
         print('Mean SDopt {} --  {}'.format(np.mean(opt_lst), np.std(opt_lst)))
         print('Mean SD gen {} -- {}'.format(np.mean(gen_lst), np.std(gen_lst)))
         print('Mean SD scheduler {} -- {}'.format(np.mean(schedul_lst), np.std(schedul_lst)))
+
+
 print("Test training time")
 test_unet()

--- a/testing/test_training_time.py
+++ b/testing/test_training_time.py
@@ -5,7 +5,7 @@ import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from medicaltorch.filters import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
 from medicaltorch import transforms as mt_transforms
 from torch import optim

--- a/testing/test_transfer_learning.py
+++ b/testing/test_transfer_learning.py
@@ -1,6 +1,3 @@
-import sys
-import json
-import os
 
 import torch
 import torch.nn as nn
@@ -17,6 +14,7 @@ OUT_CHANNEL = 1
 INITIAL_LR = 0.001
 FILM_LAYERS = [0, 0, 0, 0, 0, 0, 0, 0]
 PATH_PRETRAINED_MODEL = 'testing_data/model_unet_test.pt'
+
 
 def test_transfer_learning(film_layers=FILM_LAYERS, path_model=PATH_PRETRAINED_MODEL):
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
@@ -55,9 +53,9 @@ def test_transfer_learning(film_layers=FILM_LAYERS, path_model=PATH_PRETRAINED_M
         model.cuda()
 
     print('Layers included in the optimisation:')
-    for name,param in model.named_parameters():
+    for name, param in model.named_parameters():
         if param.requires_grad == True:
-            print("\t",name)
+            print("\t", name)
 
     total_params = sum(p.numel() for p in model.parameters())
     print(f'{total_params:,} total parameters.')
@@ -69,6 +67,7 @@ def test_transfer_learning(film_layers=FILM_LAYERS, path_model=PATH_PRETRAINED_M
     initial_lr = INITIAL_LR
     params_to_opt = filter(lambda p: p.requires_grad, model.parameters())
     optimizer = optim.Adam(params_to_opt, lr=initial_lr)
+
 
 print("test transfer learning")
 test_transfer_learning()

--- a/testing/test_undoTrans.py
+++ b/testing/test_undoTrans.py
@@ -5,7 +5,7 @@ import torch.backends.cudnn as cudnn
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-from medicaltorch.filters import SliceFilter
+from ivadomed.utils import SliceFilter
 from medicaltorch import datasets as mt_datasets
 from medicaltorch import transforms as mt_transforms
 

--- a/testing/test_undoTrans.py
+++ b/testing/test_undoTrans.py
@@ -10,7 +10,6 @@ from medicaltorch import datasets as mt_datasets
 from medicaltorch import transforms as mt_transforms
 
 from ivadomed import loader as loader
-from ivadomed.utils import *
 import ivadomed.transforms as ivadomed_transforms
 
 cudnn.benchmark = True

--- a/testing/test_undoTrans.py
+++ b/testing/test_undoTrans.py
@@ -1,17 +1,13 @@
-import os
 import numpy as np
-import time
 from random import randint
 
 import torch.backends.cudnn as cudnn
-from torch.utils.data import DataLoader, dataloader
+from torch.utils.data import DataLoader
 from torchvision import transforms
 
 from medicaltorch.filters import SliceFilter
 from medicaltorch import datasets as mt_datasets
 from medicaltorch import transforms as mt_transforms
-
-from tqdm import tqdm
 
 from ivadomed import loader as loader
 from ivadomed.utils import *
@@ -22,6 +18,7 @@ cudnn.benchmark = True
 GPU_NUMBER = 5
 SLICE_AXIS = 2
 PATH_BIDS = 'testing_data'
+
 
 def test_undo(contrast='T2star', tol=3):
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
@@ -59,21 +56,21 @@ def test_undo(contrast='T2star', tol=3):
     subject_test_lst = ['sub-test001']
 
     ds_test_noTrans = loader.BidsDataset(PATH_BIDS,
-                                  subject_lst=subject_test_lst,
-                                  target_suffix="_lesion-manual",
-                                  roi_suffix="_seg-manual",
-                                  contrast_lst=[contrast],
-                                  metadata_choice="contrast",
-                                  contrast_balance={},
-                                  slice_axis=SLICE_AXIS,
-                                  transform=transforms.Compose(test_1),
-                                  multichannel=False,
-                                  slice_filter_fn=SliceFilter(filter_empty_input=True,
-                                                                filter_empty_mask=False))
+                                         subject_lst=subject_test_lst,
+                                         target_suffix="_lesion-manual",
+                                         roi_suffix="_seg-manual",
+                                         contrast_lst=[contrast],
+                                         metadata_choice="contrast",
+                                         contrast_balance={},
+                                         slice_axis=SLICE_AXIS,
+                                         transform=transforms.Compose(test_1),
+                                         multichannel=False,
+                                         slice_filter_fn=SliceFilter(filter_empty_input=True,
+                                                                     filter_empty_mask=False))
     test_loader_noTrans = DataLoader(ds_test_noTrans, batch_size=len(ds_test_noTrans),
-                             shuffle=False, pin_memory=True,
-                             collate_fn=mt_datasets.mt_collate,
-                             num_workers=1)
+                                     shuffle=False, pin_memory=True,
+                                     collate_fn=mt_datasets.mt_collate,
+                                     num_workers=1)
     batch_noTrans = [t for i, t in enumerate(test_loader_noTrans)][0]
     input_noTrans, gt_noTrans = batch_noTrans["input"], batch_noTrans["gt"]
 
@@ -83,17 +80,17 @@ def test_undo(contrast='T2star', tol=3):
         val_undo_transform = ivadomed_transforms.UndoCompose(val_transform)
 
         ds_test = loader.BidsDataset(PATH_BIDS,
-                                      subject_lst=subject_test_lst,
-                                      target_suffix="_lesion-manual",
-                                      roi_suffix="_seg-manual",
-                                      contrast_lst=[contrast],
-                                      metadata_choice="contrast",
-                                      contrast_balance={},
-                                      slice_axis=SLICE_AXIS,
-                                      transform=val_transform,
-                                      multichannel=False,
-                                      slice_filter_fn=SliceFilter(filter_empty_input=True,
-                                                                    filter_empty_mask=False))
+                                     subject_lst=subject_test_lst,
+                                     target_suffix="_lesion-manual",
+                                     roi_suffix="_seg-manual",
+                                     contrast_lst=[contrast],
+                                     metadata_choice="contrast",
+                                     contrast_balance={},
+                                     slice_axis=SLICE_AXIS,
+                                     transform=val_transform,
+                                     multichannel=False,
+                                     slice_filter_fn=SliceFilter(filter_empty_input=True,
+                                                                 filter_empty_mask=False))
 
         test_loader = DataLoader(ds_test, batch_size=len(ds_test),
                                  shuffle=False, pin_memory=True,
@@ -132,7 +129,7 @@ def test_undo(contrast='T2star', tol=3):
                     im_noTrans = np.array(input_noTrans[smp_idx])[0]
                     im_undoTrans = np.array(rdict_undo['input'])
 
-                    plt.figure(figsize=(20,10))
+                    plt.figure(figsize=(20, 10))
                     plt.subplot(1, 2, 1)
                     plt.axis("off")
                     plt.imshow(im_noTrans, interpolation='nearest', aspect='auto', cmap='gray')
@@ -140,7 +137,7 @@ def test_undo(contrast='T2star', tol=3):
                     plt.axis("off")
                     plt.imshow(im_undoTrans, interpolation='nearest', aspect='auto', cmap='gray')
 
-                    fname_png_out = 'test_undo_err_'+str(randint(0,1000))+'.png'
+                    fname_png_out = 'test_undo_err_'+str(randint(0, 1000))+'.png'
                     plt.savefig(fname_png_out, bbox_inches='tight', pad_inches=0)
                     plt.close()
                     print('Error: please check: '+fname_png_out)
@@ -148,5 +145,7 @@ def test_undo(contrast='T2star', tol=3):
                 assert np.sum(np_noTrans-np_undoTrans) < tol
                 print('\tData content (tol: {} vox.): checked.'.format(tol))
         print('\n [INFO]: Test of {} passed successfully. '.format(name))
+
+
 print("Test undo transform")
 test_undo()


### PR DESCRIPTION
We only import from `medicaltorch` the following : `datasets, transforms, filters, metrics` so no need for  `losses, models`

Plan :

- PR 1 (this PR)
  - `filters`  -> contains only `SliceFilter` funtions, moved into `utils.py`
  - `metrics`  -> We have only reimplemented dice and hausdorff in `utils.py`  so moved in `metrics.py` and use the `medicaltorch` version for the rest
- PR 2
  - `transforms` -> combine with our transforms, so no need to override
- PR 3
  - `datasets` -> idem, combine with our datasets MRI2D / 3D in `loader.py`

Done in this PR : 
- Remove lots of unused imports
- Incorporate `filters` and `metrics`
- remove wildcard imports (`from ivadomed.utils import *`) since they make it impossible to know which function comes from where

Todo in next PRs: 
- incorporate `datasets` and `transforms`
