### PR TITLE
segment_volume(): folder_model instead of (fname_model, fname_model_metadata).

### DIFF
--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -643,8 +643,7 @@ def threshold_predictions(predictions, thr=0.5):
 def segment_volume(folder_model, fname_image, fname_roi=None):
     """Segment an image.
 
-    Segment an image (fname_image) using a already trained model given its
-    training parameters (both in folder_model). If provided, a RegionOfInterest (fname_roi)
+    Segment an image (fname_image) using a pre-trained model (folder_model). If provided, a region of interest (fname_roi)
     is used to crop the image prior to segment it.
 
     Args:

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -640,17 +640,18 @@ def threshold_predictions(predictions, thr=0.5):
     return thresholded_preds
 
 
-def segment_volume(fname_model, fname_model_metadata, fname_image, fname_roi=None):
+def segment_volume(folder_model, fname_image, fname_roi=None):
     """Segment an image.
 
-    Segment an image (fname_image) using a already trained model (fname_model) given its
-    training parameters (fname_model_metadata). If provided, a RegionOfInterest (fname_roi)
+    Segment an image (fname_image) using a already trained model given its
+    training parameters (both in folder_model). If provided, a RegionOfInterest (fname_roi)
     is used to crop the image prior to segment it.
 
     Args:
-        fname_model (string): model filename (.pt) to use.
-        fname_model_metadata (string): Configuration file filename (.json) used for the training,
-            see https://github.com/neuropoly/ivado-medical-imaging/wiki/configuration-file
+        folder_model (string): foldername which contains
+            (1) the model ('model.pt') to use
+            (2) its configuration file ('model_metadata.json') used for the training,
+                see https://github.com/neuropoly/ivado-medical-imaging/wiki/configuration-file
         fname_image (string): image filename (e.g. .nii.gz) to segment.
         roi_fname (string): Binary image filename (e.g. .nii.gz) defining a region of interest,
             e.g. spinal cord centerline, used to crop the image prior to segment it if provided.
@@ -660,6 +661,21 @@ def segment_volume(fname_model, fname_model_metadata, fname_image, fname_roi=Non
     """
     # Define device
     device = torch.device("cpu")
+
+    # Check if model folder exists
+    if os.path.isdir(folder_model):
+        # Check if model and model metadata exist
+        fname_model = os.path.join(folder_model, 'model.pt')
+        if not os.path.isfile(fname_model):
+            print('Model file not found: {}'.format(fname_model))
+            exit()
+        fname_model_metadata = os.path.join(folder_model, 'model_metadata.json')
+        if not os.path.isfile(fname_model_metadata):
+            print('Model metadata file not found: {}'.format(fname_model_metadata))
+            exit()
+    else:
+        print('Model folder not found: {}'.format(folder_model))
+        exit()
 
     # Load model training config
     with open(fname_model_metadata, "r") as fhandle:

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -663,12 +663,14 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
 
     # Check if model folder exists
     if os.path.isdir(folder_model):
+        prefix_model = os.path.basename(folder_model)
+        print(prefix_model)
         # Check if model and model metadata exist
-        fname_model = os.path.join(folder_model, 'model.pt')
+        fname_model = os.path.join(folder_model, prefix_model+'.pt')
         if not os.path.isfile(fname_model):
             print('Model file not found: {}'.format(fname_model))
             exit()
-        fname_model_metadata = os.path.join(folder_model, 'model_metadata.json')
+        fname_model_metadata = os.path.join(folder_model, prefix_model+'.json')
         if not os.path.isfile(fname_model_metadata):
             print('Model metadata file not found: {}'.format(fname_model_metadata))
             exit()

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -649,7 +649,7 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
     Args:
         folder_model (string): foldername which contains
             (1) the model ('model.pt') to use
-            (2) its configuration file ('model_metadata.json') used for the training,
+            (2) its configuration file ('model.json') used for the training,
                 see https://github.com/neuropoly/ivado-medical-imaging/wiki/configuration-file
         fname_image (string): image filename (e.g. .nii.gz) to segment.
         roi_fname (string): Binary image filename (e.g. .nii.gz) defining a region of interest,

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -648,8 +648,8 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
 
     Args:
         folder_model (string): foldername which contains
-            (1) the model ('model.pt') to use
-            (2) its configuration file ('model.json') used for the training,
+            (1) the model ('folder_model/folder_model.pt') to use
+            (2) its configuration file ('folder_model/folder_model.json') used for the training,
                 see https://github.com/neuropoly/ivado-medical-imaging/wiki/configuration-file
         fname_image (string): image filename (e.g. .nii.gz) to segment.
         roi_fname (string): Binary image filename (e.g. .nii.gz) defining a region of interest,


### PR DESCRIPTION
Instead of `fname_model, fname_model_metadata`, `segment_volume()` needs `folder_model` as argument which contains both the model and the related metadata, `folder_model/model.pt` and `folder_model/model_metadata.json` resp.

Fixes #166

To test:
```
from ivadomed.utils import segment_volume
n = segment_volume(folder_model='../duke/projects/ivado-medical-imaging/github_PR155/model_large_t2star', fname_image='../duke/projects/ivado-medical-imaging/spineGeneric_202002200220/result/sub-queensland04/anat/sub-queensland04_T2star.nii.gz')
```