### PR TITLE
Remove conditional undo_transforms on GT

### DIFF
--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -174,8 +174,8 @@ class ROICrop2D(mt_transforms.CenterCrop2D):
         else:
             rdict['input'] = self._uncrop(sample['input'], sample['input_metadata']["__centercrop"])
 
-        if self.labeled:
-            rdict['gt'] = self._uncrop(sample['gt'], sample['gt_metadata']["__centercrop"])
+        #if self.labeled:
+        rdict['gt'] = self._uncrop(sample['gt'], sample['input_metadata']["__centercrop"])
 
         sample.update(rdict)
         return sample
@@ -367,8 +367,8 @@ class CenterCrop3D(mt_transforms.MTTransform):
         npad = ((0, 0), (fw, fw), (fd, fd), (fh, fh))
         sample['input'] = np.pad(sample['input'], pad_width=npad, mode='constant', constant_values=0)
 
-        if self.labeled:
-            sample['gt'] = np.pad(sample['gt'], pad_width=npad, mode='constant', constant_values=0)
+        #if self.labeled:
+        sample['gt'] = np.pad(sample['gt'], pad_width=npad, mode='constant', constant_values=0)
 
         return sample
 
@@ -464,8 +464,8 @@ class ToTensor3D(mt_transforms.ToTensor):
     def undo_transform(self, sample):
         rdict = {}
         rdict['input'] = np.array(sample['input'])
-        if self.labeled:
-            rdict['gt'] = np.array(sample['gt'])
+        #if self.labeled:
+        rdict['gt'] = np.array(sample['gt'])
 
         sample.update(rdict)
         return sample

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -663,7 +663,6 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
     # Check if model folder exists
     if os.path.isdir(folder_model):
         prefix_model = os.path.basename(folder_model)
-        print(prefix_model)
         # Check if model and model metadata exist
         fname_model = os.path.join(folder_model, prefix_model+'.pt')
         if not os.path.isfile(fname_model):


### PR DESCRIPTION
As we use undo_transforms to reconstruct the volume from the model prediction, we should remove the condition `if self.labeled` that I introduced in a past PR #155.
This condition is however necessary for the do_transforms, where the data is not necessary labelled (e.g. via `segment_volume()`).

Note: Twin sister PR: [here](https://github.com/neuropoly/medicaltorch/pull/19).

Fixes #168.