### PR TITLE
Minor changes while training mice models

### DIFF
--- a/ivadomed/models.py
+++ b/ivadomed/models.py
@@ -33,7 +33,7 @@ class UpConv(Module):
         self.downconv = DownConv(in_feat, out_feat, drop_rate, bn_momentum)
 
     def forward(self, x, y):
-        x = F.interpolate(x, scale_factor=2, mode='bilinear', align_corners=True)
+        x = F.interpolate(x, size=y.size()[-2:], mode='bilinear', align_corners=True)
         x = torch.cat([x, y], dim=1)
         x = self.downconv(x)
         return x

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -665,6 +665,10 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
     # Undo Transforms
     undo_transforms = ivadomed_transforms.UndoCompose(do_transforms)
 
+    # Force filter_empty_mask to False if fname_roi = None
+    if fname_roi is None and 'filter_empty_mask' in context["slice_filter"]:
+        context["slice_filter"]["filter_empty_mask"] = False
+
     # Load data
     filename_pairs = [([fname_image], None, fname_roi, [{}])]
     if not context['unet_3D']:  # TODO: rename this param 'model_name' or 'kernel_dim'

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -618,8 +618,9 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
             (2) its configuration file ('folder_model/folder_model.json') used for the training,
                 see https://github.com/neuropoly/ivado-medical-imaging/wiki/configuration-file
         fname_image (string): image filename (e.g. .nii.gz) to segment.
-        roi_fname (string): Binary image filename (e.g. .nii.gz) defining a region of interest,
+        fname_roi (string): Binary image filename (e.g. .nii.gz) defining a region of interest,
             e.g. spinal cord centerline, used to crop the image prior to segment it if provided.
+            The segmentation is not performed on the slices that are empty in this image.
     Returns:
         nibabelObject: Object containing the soft segmentation.
 


### PR DESCRIPTION
Minor changes while training mice models.

1. Force `filter_empty_mask` to be `False` if `fname_roi=None`.
2. Unet architecture: Decoder: use `y.size[:-2]` as output shape of the `interpolate` instead of `factor=2` in order to be robust to any shape as input. Note: with an input of 250x250, I got an error with the previous implementation:
```
RuntimeError: invalid argument 0: Sizes of tensors must match except in dimension 1. Got 31 and 30 in dimension 2
```
3. Clarify the `segment_volume()` docstring regarding `fname_roi`.

Fixes #177.