### PR TITLE
Segment_volume: remove deprecated canonical param

### DIFF
--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -651,8 +651,7 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
                                                   slice_axis=AXIS_DCT[context['slice_axis']],
                                                   cache=True,
                                                   transform=do_transforms,
-                                                  slice_filter_fn=SliceFilter(**context["slice_filter"]),
-                                                  canonical=True)
+                                                  slice_filter_fn=SliceFilter(**context["slice_filter"]))
     else:
         print('\n3D unet is not implemented yet.')
         exit()


### PR DESCRIPTION
`MRI2DSegmentationDataset` class doesn't have `canonical` parameter anymore. This is causing an error when calling `segment_volume`. 