### PR TITLE
Modify image orientation

### DIFF
--- a/ivadomed/loader/adaptative.py
+++ b/ivadomed/loader/adaptative.py
@@ -273,9 +273,11 @@ class Bids_to_hdf5:
             else:
                 grp = self.hdf5_file.create_group(str(subject_id))
 
-            roi_pair = imed_loader.SegmentationPair(input_filename, roi_filename, metadata=metadata, cache=False)
+            roi_pair = imed_loader.SegmentationPair(input_filename, roi_filename, metadata=metadata,
+                                                    slice_axis=self.slice_axis, cache=False)
 
-            seg_pair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata, cache=False)
+            seg_pair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata,
+                                                    slice_axis=self.slice_axis, cache=False)
             print("gt filename", gt_filename)
             input_data_shape, _ = seg_pair.get_pair_shapes()
 
@@ -286,8 +288,7 @@ class Bids_to_hdf5:
 
             for idx_pair_slice in range(input_data_shape[self.slice_axis]):
 
-                slice_seg_pair = seg_pair.get_pair_slice(idx_pair_slice,
-                                                         self.slice_axis)
+                slice_seg_pair = seg_pair.get_pair_slice(idx_pair_slice)
 
                 # keeping idx of slices with gt
                 if self.slice_filter_fn:
@@ -295,7 +296,7 @@ class Bids_to_hdf5:
                 if self.slice_filter_fn and filter_fn_ret_seg:
                     useful_slices.append(idx_pair_slice)
 
-                roi_pair_slice = roi_pair.get_pair_slice(idx_pair_slice, self.slice_axis)
+                roi_pair_slice = roi_pair.get_pair_slice(idx_pair_slice)
 
                 input_volumes.append(slice_seg_pair["input"][0])
 

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -115,6 +115,45 @@ def filter_roi(ds, nb_nonzero_thr):
     return ds
 
 
+def orient_img_hwd(data, slice_axis):
+    """
+    Orient a given RAS image to height, width, depth according to slice axis.
+    :return: numpy array oriented with the following dimensions: (height, width, depth)
+    """
+    if slice_axis == 0:
+        return data.transpose(2, 1, 0)
+    elif slice_axis == 1:
+        return data.transpose(2, 0, 1)
+    elif slice_axis == 2:
+        return data
+
+
+def orient_img_ras(data, slice_axis):
+    """
+    Orient a given numpy array with dimensions (height, width, depth) to RAS oriented.
+    :return: numpy array oriented in RAS
+    """
+    if slice_axis == 0:
+        return data.transpose(2, 1, 0)
+    elif slice_axis == 1:
+        return data.transpose(1, 2, 0)
+    elif slice_axis == 2:
+        return data
+
+
+def orient_shapes_hwd(data, slice_axis):
+    """
+    Swap dimensions according to match the height, width, depth orientation
+    :return: numpy array containing the swapped dimensions
+    """
+    if slice_axis == 0:
+        return np.array(data)[[2, 1, 0]]
+    elif slice_axis == 1:
+        return np.array(data)[[2, 0, 1]]
+    elif slice_axis == 2:
+        return np.array(data)
+
+
 class SampleMetadata(object):
     def __init__(self, d=None):
         self.metadata = {} or d

--- a/ivadomed/loader/utils.py
+++ b/ivadomed/loader/utils.py
@@ -134,9 +134,9 @@ def orient_img_ras(data, slice_axis):
     :return: numpy array oriented in RAS
     """
     if slice_axis == 0:
-        return data.transpose(2, 1, 0)
+        return data.transpose(2, 1, 0) if len(data.shape) == 3 else data.transpose(0, 3, 2, 1)
     elif slice_axis == 1:
-        return data.transpose(1, 2, 0)
+        return data.transpose(1, 2, 0) if len(data.shape) == 3 else data.transpose(0, 2, 3, 1)
     elif slice_axis == 2:
         return data
 

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -712,7 +712,7 @@ def cmd_test(context):
             if not i_monteCarlo:
                 batch["input_metadata"] = batch["input_metadata"][0]  # Take only metadata from one input
                 batch["gt_metadata"] = batch["gt_metadata"][0]  # Take only metadata from one label
-                if batch["roi"][0] is not None:
+                if "roi" in batch and batch["roi"][0] is not None:
                     batch["roi"] = batch["roi"][0]
                     batch["roi_metadata"] = batch["roi_metadata"][0]
 
@@ -774,7 +774,7 @@ def cmd_test(context):
                         fname_pred = fname_pred.split('.nii.gz')[0] + '_' + str(i_monteCarlo).zfill(2) + '.nii.gz'
 
                     # Choose only one modality
-                    output_nii = imed_utils.pred_to_nib(data_lst=rdict_undo['gt'].transpose((2, 3, 1, 0)),
+                    output_nii = imed_utils.pred_to_nib(data_lst=rdict_undo['gt'],
                                                         z_lst=[],
                                                         fname_ref=fname_ref,
                                                         fname_out=fname_pred,

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -774,7 +774,7 @@ def cmd_test(context):
                         fname_pred = fname_pred.split('.nii.gz')[0] + '_' + str(i_monteCarlo).zfill(2) + '.nii.gz'
 
                     # Choose only one modality
-                    output_nii = imed_utils.pred_to_nib(data_lst=rdict_undo['gt'],
+                    output_nii = imed_utils.pred_to_nib(data_lst=rdict_undo['gt'][0, ],
                                                         z_lst=[],
                                                         fname_ref=fname_ref,
                                                         fname_out=fname_pred,
@@ -784,8 +784,8 @@ def cmd_test(context):
 
                     # Save merged labels with color
                     output_nii_shape = output_nii.get_fdata().shape
-                    if len(output_nii_shape) == 4 and output_nii_shape[-1] > 1:
-                        imed_utils.save_color_labels(output_nii.get_fdata(),
+                    if isinstance(rdict_undo['gt'], np.ndarray) and rdict_undo['gt'].shape[0] > 1:
+                        imed_utils.save_color_labels(rdict_undo['gt'],
                                                      context['binarize_prediction'],
                                                      rdict_undo['input_metadata']['gt_filenames'][0],
                                                      fname_pred.split(".nii.gz")[0] + '_color.nii.gz',

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -774,7 +774,7 @@ def cmd_test(context):
                         fname_pred = fname_pred.split('.nii.gz')[0] + '_' + str(i_monteCarlo).zfill(2) + '.nii.gz'
 
                     # Choose only one modality
-                    output_nii = imed_utils.pred_to_nib(data_lst=rdict_undo['gt'][0, ],
+                    output_nii = imed_utils.pred_to_nib(data_lst=rdict_undo['gt'],
                                                         z_lst=[],
                                                         fname_ref=fname_ref,
                                                         fname_out=fname_pred,
@@ -783,7 +783,6 @@ def cmd_test(context):
                                                         bin_thr=0.5 if context["binarize_prediction"] else -1)
 
                     # Save merged labels with color
-                    output_nii_shape = output_nii.get_fdata().shape
                     if isinstance(rdict_undo['gt'], np.ndarray) and rdict_undo['gt'].shape[0] > 1:
                         imed_utils.save_color_labels(rdict_undo['gt'],
                                                      context['binarize_prediction'],

--- a/ivadomed/transforms.py
+++ b/ivadomed/transforms.py
@@ -277,12 +277,8 @@ class ToTensor(IMEDTransform):
                 if isinstance(gt_data, list):
                     # multiple GT
                     # torch.cat is used to be compatible with StackTensors
-                    ret_gt = torch.cat([torch.from_numpy(np.ascontiguousarray(item)) if isinstance(item, np.ndarray)
-                                        else F.to_tensor(item) for item in gt_data], dim=0)
-
-                    # Add dim 0 for 3D images (i.e. 2D slices with multiple GT)
-                    if isinstance(gt_data[0], np.ndarray) and len(gt_data[0].shape) == 3:
-                        ret_gt = ret_gt.unsqueeze(0)
+                    ret_gt = torch.stack([torch.from_numpy(np.ascontiguousarray(item)) if isinstance(item, np.ndarray)
+                                          else F.to_tensor(item)[0] for item in gt_data], dim=0)
 
                 else:
                     # single GT
@@ -655,7 +651,7 @@ class CenterCrop3D(IMEDTransform):
                             pad_width=npad,
                             mode='constant',
                             constant_values=0)
-        gt_undo = np.pad(sample['input'],
+        gt_undo = np.pad(sample['gt'],
                          pad_width=npad,
                          mode='constant',
                          constant_values=0)

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -349,11 +349,16 @@ def pred_to_nib(data_lst, z_lst, fname_ref, fname_out, slice_axis, debug=False, 
         # create data and stack on depth dimension
         arr = np.stack(tmp_lst, axis=-1)
 
+        # Reorient data
+        arr_pred_ref_space = reorient_image(arr, slice_axis, nib_ref, nib_ref_can)
+
     else:
         arr = data_lst
-
-    # Reorient data
-    arr_pred_ref_space = reorient_image(arr, slice_axis, nib_ref, nib_ref_can)
+        n_channel = arr.shape[0]
+        oriented_volumes = []
+        for i in range(n_channel):
+            oriented_volumes.append(reorient_image(arr[i, ], slice_axis, nib_ref, nib_ref_can))
+        arr_pred_ref_space = np.asarray(oriented_volumes).transpose((1, 2, 3, 0))
 
     if bin_thr >= 0:
         arr_pred_ref_space = imed_postpro.threshold_predictions(arr_pred_ref_space, thr=bin_thr)

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -358,6 +358,7 @@ def pred_to_nib(data_lst, z_lst, fname_ref, fname_out, slice_axis, debug=False, 
         oriented_volumes = []
         for i in range(n_channel):
             oriented_volumes.append(reorient_image(arr[i, ], slice_axis, nib_ref, nib_ref_can))
+        # transpose to locate the channel dimension at the end to properly see image on viewer
         arr_pred_ref_space = np.asarray(oriented_volumes).transpose((1, 2, 3, 0))
 
     if bin_thr >= 0:

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -799,6 +799,7 @@ class HookBasedFeatureExtractor(nn.Module):
 
 
 def reorient_image(arr, slice_axis, nib_ref, nib_ref_canonical):
+    # Orient image in RAS according to slice axis
     arr_ras = imed_loaded_utils.orient_img_ras(arr, slice_axis)
 
     # https://gitship.com/neuroscience/nibabel/blob/master/nibabel/orientations.py

--- a/testing/test_orientation.py
+++ b/testing/test_orientation.py
@@ -4,12 +4,12 @@ from ivadomed import utils as imed_utils
 from ivadomed.loader import loader as imed_loader, utils as imed_loader_utils
 from torchvision import transforms as torch_transforms
 from torch.utils.data import DataLoader
+import numpy as np
 
 import nibabel as nib
 
 GPU_NUMBER = 0
 PATH_BIDS = 'testing_data'
-SLICE_AXIS = [0, 1, 2]
 
 
 def test_image_orientation():
@@ -21,56 +21,77 @@ def test_image_orientation():
 
     train_lst = ['sub-test001']
 
-    training_transform_3d_list = [
-        imed_transforms.CenterCrop3D(size=[96, 96, 16]),
-        imed_transforms.ToTensor3D(),
-        imed_transforms.NormalizeInstance3D(),
-        imed_transforms.StackTensors()
+    training_transform_list = [
+        imed_transforms.Resample(hspace=2, wspace=2),
+        imed_transforms.CenterCrop2D(size=[96, 96]),
+        imed_transforms.ToTensor(),
+        imed_transforms.NormalizeInstance(),
     ]
-    training_transform_3d = torch_transforms.Compose(training_transform_3d_list)
-    training_undo_transform = imed_transforms.UndoCompose(training_transform_3d_list)
+    training_transform = torch_transforms.Compose(training_transform_list)
+    training_undo_transform = imed_transforms.UndoCompose(training_transform)
 
-    ds_3d = imed_loader.Bids3DDataset(PATH_BIDS,
-                                      subject_lst=train_lst,
-                                      target_suffix=["_seg-manual"],
-                                      contrast_lst=['T1w', 'T2w'],
-                                      metadata_choice="without",
-                                      contrast_balance={},
-                                      slice_axis=2,
-                                      transform=training_transform_3d,
-                                      multichannel=False,
-                                      length=[96, 96, 16],
-                                      padding=0)
+    for slice_axis in [0, 1, 2]:
+        ds = imed_loader.BidsDataset(PATH_BIDS,
+                                     subject_lst=train_lst,
+                                     target_suffix=["_seg-manual"],
+                                     contrast_lst=['T1w'],
+                                     metadata_choice="without",
+                                     contrast_balance={},
+                                     slice_axis=slice_axis,
+                                     transform=training_transform,
+                                     multichannel=False)
 
-    loader_3d = DataLoader(ds_3d, batch_size=1,
-                           shuffle=True, pin_memory=True,
-                           collate_fn=imed_loader_utils.imed_collate,
-                           num_workers=1)
+        loader = DataLoader(ds, batch_size=1,
+                            shuffle=True, pin_memory=True,
+                            collate_fn=imed_loader_utils.imed_collate,
+                            num_workers=1)
 
-    input_filename, gt_filename, roi_filename, metadata = ds_3d.filename_pairs[0]
-    segpair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata)
-    nib_original = nib.load(input_filename)
-    input_init = nib_original.get_fdata()
-    input_ras = nib.as_closest_canonical(nib_original).get_fdata()
-    input_hwd, gt = segpair.get_pair_data()
+        input_filename, gt_filename, roi_filename, metadata = ds.filename_pairs[0]
+        segpair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata)
+        nib_original = nib.load(input_filename[0])
+        input_init = nib_original.get_fdata()
+        input_ras = nib.as_closest_canonical(nib_original).get_fdata()
+        img, gt = segpair.get_pair_data()
+        input_hwd = img[0]
 
-    for i, batch in enumerate(loader_3d):
-        input_samples, gt_samples = batch["input"], batch["gt"]
+        pred_tmp_lst, z_tmp_lst = [], []
+        for i, batch in enumerate(loader):
+            input_samples, gt_samples = batch["input"], batch["gt"]
 
-        for smp_idx in range(len(batch['gt'])):
-            # undo transformations
-            rdict = {}
-            for k in batch.keys():
-                rdict[k] = batch[k][smp_idx]
-            rdict_undo = training_undo_transform(rdict)
-            input_hwd_2 = rdict_undo['input']
+            batch["input_metadata"] = batch["input_metadata"][0]  # Take only metadata from one input
+            batch["gt_metadata"] = batch["gt_metadata"][0]  # Take only metadata from one label
 
-            fname_ref = rdict_undo['input_metadata']['gt_filenames'][0]
-            nib_ref = nib.load(fname_ref)
-            nib_ref_can = nib.as_closest_canonical(nib_ref)
-            input_ras_2 = nib_ref_can.get_fdata()
-            input_init_2 = imed_utils.reorient_image(input_hwd_2, SLICE_AXIS, nib_ref, nib_ref_can)
+            for smp_idx in range(len(batch['gt'])):
+                # undo transformations
+                rdict = {}
+                for k in batch.keys():
+                    rdict[k] = batch[k][smp_idx]
+                rdict_undo = training_undo_transform(rdict)
 
+                # add new sample to pred_tmp_lst
+                pred_tmp_lst.append(imed_utils.pil_list_to_numpy(rdict_undo['input']))
+                z_tmp_lst.append(int(rdict_undo['input_metadata']['slice_index']))
+                fname_ref = rdict_undo['input_metadata']['gt_filenames'][0]
+
+                if pred_tmp_lst and i == len(loader) - 1:
+                    # save the completely processed file as a nii
+                    nib_ref = nib.load(fname_ref)
+                    nib_ref_can = nib.as_closest_canonical(nib_ref)
+
+                    tmp_lst = []
+                    for z in range(nib_ref_can.header.get_data_shape()[slice_axis]):
+                        if not z in z_tmp_lst:
+                            tmp_lst.append(np.zeros(pred_tmp_lst[0].shape))
+                        else:
+                            tmp_lst.append(pred_tmp_lst[z_tmp_lst.index(z)])
+
+                    # create data and stack on depth dimension
+                    input_hwd_2 = np.stack(tmp_lst, axis=-1)
+                    input_ras_2 = imed_loader_utils.orient_img_ras(nib_ref_can.get_fdata())
+                    input_init_2 = imed_utils.reorient_image(input_hwd_2, slice_axis, nib_ref, nib_ref_can)
+
+                    # re-init pred_stack_lst
+                    pred_tmp_lst, z_tmp_lst = [], []
 
 
 print("Test image orientation")

--- a/testing/test_orientation.py
+++ b/testing/test_orientation.py
@@ -50,12 +50,12 @@ def test_image_orientation():
                             num_workers=1)
 
         input_filename, gt_filename, roi_filename, metadata = ds.filename_pairs[0]
-        segpair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata)
+        segpair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata, slice_axis=slice_axis)
         nib_original = nib.load(gt_filename[0])
         # Get image with original, ras and hwd orientations
         input_init = nib_original.get_fdata()
         input_ras = nib.as_closest_canonical(nib_original).get_fdata()
-        img, gt = segpair.get_pair_data(slice_axis)
+        img, gt = segpair.get_pair_data()
         input_hwd = gt[0]
 
         pred_tmp_lst, z_tmp_lst = [], []
@@ -92,7 +92,6 @@ def test_image_orientation():
                     assert imed_losses.dice_loss(input_ras_2, input_ras) >= 0.85
                     input_init_2 = imed_utils.reorient_image(input_hwd_2, slice_axis, nib_ref, nib_ref_can)
                     assert imed_losses.dice_loss(input_init_2, input_init) >= 0.85
-
 
                     # re-init pred_stack_lst
                     pred_tmp_lst, z_tmp_lst = [], []

--- a/testing/test_orientation.py
+++ b/testing/test_orientation.py
@@ -1,0 +1,77 @@
+import torch
+from ivadomed import transforms as imed_transforms
+from ivadomed import utils as imed_utils
+from ivadomed.loader import loader as imed_loader, utils as imed_loader_utils
+from torchvision import transforms as torch_transforms
+from torch.utils.data import DataLoader
+
+import nibabel as nib
+
+GPU_NUMBER = 0
+PATH_BIDS = 'testing_data'
+SLICE_AXIS = [0, 1, 2]
+
+
+def test_image_orientation():
+    device = torch.device("cuda:" + str(GPU_NUMBER) if torch.cuda.is_available() else "cpu")
+    cuda_available = torch.cuda.is_available()
+    if cuda_available:
+        torch.cuda.set_device(device)
+        print("Using GPU number {}".format(device))
+
+    train_lst = ['sub-test001']
+
+    training_transform_3d_list = [
+        imed_transforms.CenterCrop3D(size=[96, 96, 16]),
+        imed_transforms.ToTensor3D(),
+        imed_transforms.NormalizeInstance3D(),
+        imed_transforms.StackTensors()
+    ]
+    training_transform_3d = torch_transforms.Compose(training_transform_3d_list)
+    training_undo_transform = imed_transforms.UndoCompose(training_transform_3d_list)
+
+    ds_3d = imed_loader.Bids3DDataset(PATH_BIDS,
+                                      subject_lst=train_lst,
+                                      target_suffix=["_seg-manual"],
+                                      contrast_lst=['T1w', 'T2w'],
+                                      metadata_choice="without",
+                                      contrast_balance={},
+                                      slice_axis=2,
+                                      transform=training_transform_3d,
+                                      multichannel=False,
+                                      length=[96, 96, 16],
+                                      padding=0)
+
+    loader_3d = DataLoader(ds_3d, batch_size=1,
+                           shuffle=True, pin_memory=True,
+                           collate_fn=imed_loader_utils.imed_collate,
+                           num_workers=1)
+
+    input_filename, gt_filename, roi_filename, metadata = ds_3d.filename_pairs[0]
+    segpair = imed_loader.SegmentationPair(input_filename, gt_filename, metadata=metadata)
+    nib_original = nib.load(input_filename)
+    input_init = nib_original.get_fdata()
+    input_ras = nib.as_closest_canonical(nib_original).get_fdata()
+    input_hwd, gt = segpair.get_pair_data()
+
+    for i, batch in enumerate(loader_3d):
+        input_samples, gt_samples = batch["input"], batch["gt"]
+
+        for smp_idx in range(len(batch['gt'])):
+            # undo transformations
+            rdict = {}
+            for k in batch.keys():
+                rdict[k] = batch[k][smp_idx]
+            rdict_undo = training_undo_transform(rdict)
+            input_hwd_2 = rdict_undo['input']
+
+            fname_ref = rdict_undo['input_metadata']['gt_filenames'][0]
+            nib_ref = nib.load(fname_ref)
+            nib_ref_can = nib.as_closest_canonical(nib_ref)
+            input_ras_2 = nib_ref_can.get_fdata()
+            input_init_2 = imed_utils.reorient_image(input_hwd_2, SLICE_AXIS, nib_ref, nib_ref_can)
+
+
+
+print("Test image orientation")
+test_image_orientation()


### PR DESCRIPTION
Images are loaded, then are oriented in RAS. According to slice axis (axial, coronal or sagittal), this creates images with varying dimensions relatively to height, width and depth. For instance, to extract a 2D slice, this is needed:
```python
        for data_object in input_dataobj:
            if slice_axis == 2:
                input_slices.append(np.asarray(data_object[..., slice_index],
                                               dtype=np.float32))
            elif slice_axis == 1:
                input_slices.append(np.asarray(data_object[:, slice_index, ...],
                                               dtype=np.float32))
            elif slice_axis == 0:
                input_slices.append(np.asarray(data_object[slice_index, ...],
                                               dtype=np.float32))
```
Currently, the `Resample` transformation only works for axial slices since the zooms are extracted from the 2 first dimensions:
```python
            input_meta_dict.append(imed_loader_utils.SampleMetadata({
                "zooms": handle.header.get_zooms()[:2],
                "data_shape": handle.header.get_data_shape()[:2],
            }))
```
In ToTensor transformation, F.to_tensor() method used converts numpy arrays into torch tensors, but also apply a transpose, changing the dimensions.

To resolve this issues, all the images are reoriented with the following dimensions: (batch number, channel number, height, width, depth). This is coherent with the refactor transform PR #213 that will use only numpy. Reorienting according to dimensions will be needed for this PR if we want to get rid of image list.
