### PR TITLE
Onnx model

### DIFF
--- a/dev/convert_to_onnx.py
+++ b/dev/convert_to_onnx.py
@@ -1,0 +1,47 @@
+##############################################################
+#
+# This converts a .pt model to ONNX format
+#
+# Usage: python dev/convert_to_onnx.py -m path/to/model.pt -d 3
+#
+# Contributors: Andreanne
+#
+##############################################################
+
+import argparse
+import torch
+
+from ivadomed import utils as imed_utils
+import copy
+import joblib
+import json
+import logging
+import os
+import pandas as pd
+import random
+import shutil
+import sys
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--model", dest="model", required=True, type=str, help="Path to .pt model.")
+    parser.add_argument("-d", "--dimension", dest="dimension", required=True,
+                        type=int, help="Input dimension (2 for 2D inputs, 3 for 3D inputs).")
+    parser.add_argument("-g", "--gpu", dest="gpu", default=0, type=str, help="GPU number if available.")
+    return parser
+
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+
+    if torch.cuda.is_available():
+        device = "cuda:" + str(args.gpu)
+    else:
+        device = "cpu"
+
+    model = torch.load(args.model, map_location=device)
+    dummy_input = torch.randn(1, 1, 96, 96, device=device) if args.dimension == 2 \
+                  else torch.randn(1, 1, 96, 96, 96, device=device)
+    imed_utils.save_onnx_model(model, dummy_input, args.model.replace("pt", "onnx"))

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -525,7 +525,9 @@ def cmd_train(context):
             else:
                 best_validation_dice = best_validation_loss
                 best_training_dice = best_training_loss
-            torch.save(model, "./" + context["log_directory"] + "/best_model.pt")
+            model_path = os.path.join(context['log_directory'], 'best_model.pt')
+            torch.save(model, model_path)
+            imed_utils.save_onnx_model(model, var_input, model_path.replace('pt', 'onnx'))
 
         # Early stopping : break if val loss doesn't improve by at least epsilon percent for N=patience epochs
         val_losses.append(val_loss_total_avg)

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -540,7 +540,10 @@ def cmd_train(context):
             break
 
     # Save final model
-    torch.save(model, "./" + context["log_directory"] + "/final_model.pt")
+    model_path = os.path.join(context['log_directory'], 'final_model.pt')
+    torch.save(model, model_path)
+    imed_utils.save_onnx_model(model, var_input, model_path.replace('pt', 'onnx'))
+
     if film_bool:  # save clustering and OneHotEncoding models
         joblib.dump(metadata_clustering_models, "./" +
                     context["log_directory"] + "/clustering_models.joblib")

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -971,7 +971,9 @@ def unstack_tensors(sample):
 
 def save_onnx_model(model, inputs, model_path):
     model.eval()
-    dynamic_axes = list(range(len(inputs.shape)))
+    dynamic_axes = {0: 'batch', 1: 'num_channels', 2: 'height', 3: 'width', 4: 'depth'}
+    if len(inputs.shape) == 4:
+        del dynamic_axes[4]
     torch.onnx.export(model, inputs, model_path,
                       opset_version=11,
                       input_names=['input'],

--- a/ivadomed/utils.py
+++ b/ivadomed/utils.py
@@ -622,11 +622,13 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
     #  ivadomed, and do it in a separate, more specific file (e.g. models.py)
     if os.path.isdir(folder_model):
         prefix_model = os.path.basename(folder_model)
-        # Check if model and model metadata exist
-        fname_model = os.path.join(folder_model, prefix_model + '.pt')
+        # Check if model and model metadata exist. Verify if ONNX model exists, if not try to find .pt model
+        fname_model = os.path.join(folder_model, prefix_model + '.onnx')
         if not os.path.isfile(fname_model):
-            print('Model file not found: {}'.format(fname_model))
-            exit()
+            fname_model = os.path.join(folder_model, prefix_model + '.pt')
+            if not os.path.exists(fname_model):
+                print('Model file not found: {}'.format(fname_model))
+                exit()
         fname_model_metadata = os.path.join(folder_model, prefix_model + '.json')
         if not os.path.isfile(fname_model_metadata):
             print('Model metadata file not found: {}'.format(fname_model_metadata))
@@ -687,16 +689,18 @@ def segment_volume(folder_model, fname_image, fname_roi=None):
                              num_workers=0)
 
     # Load model
-    model = torch.load(fname_model, map_location=device)
+    if fname_model.endswith('.pt'):
+        model = torch.load(fname_model, map_location=device)
 
-    # Inference time
-    model.eval()
+        # Inference time
+        model.eval()
 
     # Loop across batches
     preds_list, slice_idx_list = [], []
     for i_batch, batch in enumerate(data_loader):
         with torch.no_grad():
-            preds = model(batch['input'])
+            img = batch['input']
+            preds = model(img) if fname_model.endswith('.pt') else onnx_inference(fname_model, img)
 
         # Reconstruct 3D object
         for i_slice in range(len(preds)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ h5py
 joblib
 matplotlib>=3.0.3
 nibabel
+onnxruntime
 pandas
 pillow>=7.0.0
 pytest

--- a/testing/test_onnx.py
+++ b/testing/test_onnx.py
@@ -1,0 +1,37 @@
+import os
+import nibabel as nib
+import torch
+import numpy as np
+import json
+import shutil
+
+from ivadomed import utils as imed_utils
+from ivadomed import models as imed_models
+
+
+PATH_BIDS = 'testing_data'
+IMAGE_PATH = os.path.join(PATH_BIDS, "sub-test001", "anat", "sub-test001_T1w.nii.gz")
+PATH_MODEL = os.path.join(PATH_BIDS, 'model')
+PATH_MODEL_ONNX = os.path.join(PATH_MODEL, 'model.onnx')
+PATH_MODEL_PT = PATH_MODEL_ONNX.replace('onnx', 'pt')
+LENGTH_3D = (112, 112, 112)
+
+
+def test_onnx():
+    model = imed_models.UNet3D(1, 1)
+    if not os.path.exists(PATH_MODEL):
+        os.mkdir(PATH_MODEL)
+    torch.save(model, PATH_MODEL_PT)
+    img = nib.load(IMAGE_PATH).get_fdata().astype('float32')[:16, :64, :32]
+    # Add batch and channel dimensions
+    img_tensor = torch.tensor(img).unsqueeze(0).unsqueeze(0)
+    dummy_input = torch.randn(1, 1, 32, 32, 32)
+    imed_utils.save_onnx_model(model, dummy_input, PATH_MODEL_ONNX)
+
+    model = torch.load(PATH_MODEL_PT)
+    model.eval()
+    out_pt = model(img_tensor).detach().numpy()
+
+    out_onnx = imed_utils.onnx_inference(PATH_MODEL_ONNX, img_tensor).numpy()
+    shutil.rmtree(PATH_MODEL)
+    assert np.allclose(out_pt, out_onnx, rtol=1e-3)


### PR DESCRIPTION
This PR implements the use of ONNX models (#232 ).
Changes: 
- Modify segment_volume to load `.onnx` model if available (`.pt` are still supported)
- Save models in .onnx format at the end of training
- Add a script in dev (dev/convert_to_onnx.py) to convert .pt models in .onnx. Can be used as follow 
  where `dimension` represents 2D or 3D models:

  `python dev/convert_to_onnx --model path/to/model.pt --dimension 2 (--gpu 0)`

- Add test_onnx
- Add onnxruntime dependency

