### PR TITLE
Add Tversky and Focal Tversky Losses

### DIFF
--- a/ivadomed/losses.py
+++ b/ivadomed/losses.py
@@ -210,7 +210,7 @@ class FocalTverskyLoss(TverskyLoss):
             # Compute Tversky index
             tversky_index = self.tversky.tversky_index(y_pred, y_true)
             # Compute Focal Tversky loss, Equation 4 in the original paper
-            focal_tversky_sum += torch.pow(1-tversky_index, exponent=1/self.gamma)
+            focal_tversky_sum += torch.pow(1 - tversky_index, exponent=1 / self.gamma)
 
         # TODO: Take the opposite?
         return focal_tversky_sum / n_classes

--- a/ivadomed/losses.py
+++ b/ivadomed/losses.py
@@ -124,7 +124,7 @@ class TverskyLoss(nn.Module):
 
     """
 
-    def __init__(self, alpha=0.3, beta=0.7, smooth=1.0):
+    def __init__(self, alpha=0.7, beta=0.3, smooth=1.0):
         """
         Args:
             alpha (float): weight of false positive voxels
@@ -158,7 +158,7 @@ class TverskyLoss(nn.Module):
         fp = torch.sum((1 - y_true) * y_pred)
         # Compute Tversky for the current class, see Equation 3 of the original paper
         numerator = tp + self.smooth
-        denominator = tp + self.alpha * fn + self.beta * fp + self.smooth
+        denominator = tp + self.alpha * fp + self.beta * fn + self.smooth
         tversky_label = numerator / denominator
         return tversky_label
 

--- a/ivadomed/losses.py
+++ b/ivadomed/losses.py
@@ -114,3 +114,26 @@ class GeneralizedDiceLoss(nn.Module):
         denominator = ((input + target).sum(-1) * class_weights).sum()
 
         return 1. - 2. * intersect / denominator.clamp(min=self.epsilon)
+
+
+class TverskyLoss(nn.Module):
+    """Tversky Loss.
+
+    Compute the Tversky loss defined in:
+        Sadegh et al. (2017) Tversky loss function for image segmentation using 3D fully convolutional deep networks
+
+    """
+
+    def __init__(self, alpha=0.5, beta=0.5):
+        super(TverskyLoss, self).__init__()
+        self.alpha = alpha
+        self.beta = beta
+
+    def forward(self, input, target):
+        n_classes = input.shape[1]
+
+        # TODO: Add class_of_interest?
+
+        for i_label in range(n_classes):
+            y_pred, y_true = input[:, i_label, ], target[:, i_label, ]
+

--- a/ivadomed/losses.py
+++ b/ivadomed/losses.py
@@ -124,12 +124,16 @@ class TverskyLoss(nn.Module):
 
     """
 
-    def __init__(self, alpha=0.7, beta=0.3, smooth=1.0):
+    def __init__(self, alpha=0.3, beta=0.7, smooth=1.0):
         """
         Args:
             alpha (float): weight of false positive voxels
             beta  (float): weight of false negative voxels
             smooth (float): epsilon to avoid division by zero, when both Numerator and Denominator of Tversky are zeros
+
+        Notes:
+            - setting alpha=beta=0.5: equivalent to DiceLoss
+            - default parameters were suggested by https://arxiv.org/pdf/1706.05721.pdf
         """
         super(TverskyLoss, self).__init__()
         self.alpha = alpha

--- a/ivadomed/losses.py
+++ b/ivadomed/losses.py
@@ -124,7 +124,7 @@ class TverskyLoss(nn.Module):
 
     """
 
-    def __init__(self, alpha=0.5, beta=0.5, smooth=1.0):
+    def __init__(self, alpha=0.7, beta=0.3, smooth=1.0):
         """
         Args:
             alpha (float): weight of false positive voxels
@@ -138,6 +138,7 @@ class TverskyLoss(nn.Module):
 
     def forward(self, input, target):
         n_classes = input.shape[1]
+        tversky_sum = 0.
 
         # TODO: Add class_of_interest?
         for i_label in range(n_classes):
@@ -153,4 +154,7 @@ class TverskyLoss(nn.Module):
             numerator = tp + self.smooth
             denominator = tp + self.alpha * fn + self.beta * fp + self.smooth
             tversky_label = numerator / denominator
+            # Add to the total
+            tversky_sum += tversky_label
 
+        return - tversky_sum / n_classes

--- a/ivadomed/losses.py
+++ b/ivadomed/losses.py
@@ -162,3 +162,51 @@ class TverskyLoss(nn.Module):
             tversky_sum += tversky_label
 
         return - tversky_sum / n_classes
+
+
+class FocalTverskyLoss(nn.Module):
+    """Focal Tversky Loss.
+
+    Compute the Focal Tversky loss defined in:
+        Abraham et al. (2018) A Novel Focal Tversky loss function with improved Attention U-Net for lesion segmentation
+
+    """
+
+    def __init__(self, alpha=0.7, beta=0.3, gamma=1.33, smooth=1.0):
+        """
+        Args:
+            alpha (float): weight of false positive voxels
+            beta  (float): weight of false negative voxels
+            gamma (float): typically between 1 and 3. Control between easy background and hard ROI training examples.
+            smooth (float): epsilon to avoid division by zero, when both Numerator and Denominator of Tversky are zeros
+
+        Notes:
+            - setting alpha=beta=0.5 and gamma=1: equivalent to DiceLoss
+            - default parameters were suggested by https://arxiv.org/pdf/1810.07842.pdf
+        """
+        super(FocalTverskyLoss, self).__init__()
+        self.gamma = gamma
+        self.tversky = TverskyLoss(alpha=alpha, beta=beta, smooth=smooth)
+
+    def forward(self, input, target):
+        n_classes = input.shape[1]
+        tversky_sum = 0.
+
+        # TODO: Add class_of_interest?
+        for i_label in range(n_classes):
+            # Get samples for a given class
+            y_pred, y_true = input[:, i_label, ], target[:, i_label, ]
+            # Compute TP
+            tp = torch.sum(y_true * y_pred)
+            # Compute FN
+            fn = torch.sum(y_true * (1 - y_pred))
+            # Compute FP
+            fp = torch.sum((1 - y_true) * y_pred)
+            # Compute Tversky for the current class, see Equation 3 of the original paper
+            numerator = tp + self.smooth
+            denominator = tp + self.alpha * fn + self.beta * fp + self.smooth
+            tversky_label = numerator / denominator
+            # Add to the total
+            tversky_sum += tversky_label
+
+        return - tversky_sum / n_classes


### PR DESCRIPTION
#### Original papers:
- [Tversky Loss 2017](https://arxiv.org/pdf/1706.05721.pdf)
- [Tversky Focal Loss 2018](https://arxiv.org/pdf/1810.07842.pdf)

#### Motivation:
Have been recommended for high class imbalance issues.

#### Limitation:
Some hyperparameters to optimise.

#### Background:
- Tversky Index is a asymmetric similarity measure
- If alpha=beta=0.5 --> Tversky index is equivalent to the Dice Score
- If alpha=beta=1 --> Tversky index is equivalent to the Jaccard Index
- alpha > beta --> penalise false negatives
- Focal Tversky Loss --> Same idea than Focal Loss: non-linear nature of the loss gives control over how the loss behaves at different values of the Tversky index obtained.
- For gamma > 1: the loss is higher for samples where Tversky < 0.5 --> the model focus on harder samples.