### PR TITLE
Added contributing and License in main documentation 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,7 @@
 First off, thanks for taking the time to contribute!
 
 When contributing to this repository, please first discuss the change you wish
-to make via Github issue, email, or any other method with the core team before
-making a change.
+to make by opening a new [Github issue](https://github.com/neuropoly/ivado-medical-imaging/issues).
 
 Contributions relating to content of the Github repository can be
 submitted through Github pull requests (PR).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-First off, thanks for taking the time to contribute! :tada::+1:
+First off, thanks for taking the time to contribute!
 
 When contributing to this repository, please first discuss the change you wish
 to make via Github issue, email, or any other method with the core team before
@@ -43,7 +43,7 @@ If you experience an error, copy/paste the Terminal output (include your
 syntax) and please follow these guidelines for clarity:
 
 -   If there is less than 10 lines of text, embed it directly in your
-    comment in github. Use \"\~\~\~\" to format as code.
+    comment in Github. Use \"\~\~\~\" to format as code.
 -   If there is 10+ lines, either use an external website such as
     [pastebin](https://pastebin.com/) (copy/paste your text and include
     the URL in your comment), or use [collapsable Github markdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,29 @@ When contributing to this repository, please first discuss the change you wish
 to make via Github issue, email, or any other method with the core team before
 making a change.
 
+Contributions relating to content of the Github repository can be
+submitted through Github pull requests (PR).
+
+PR for bug fixes or new features should be based on the
+`master` branch.
+
+The following Github documentation may be useful:
+
+-   See [Using Pull
+    Requests](https://help.github.com/articles/using-pull-requests) for
+    more information about Pull Requests.
+-   See [Fork A Repo](http://help.github.com/forking/) for an
+    introduction to forking a repository.
+-   See [Creating
+    branches](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/)
+    for an introduction on branching within GitHub.
+
+**For external contributors:** Please fork this repository, make the desired
+changes, and open a Pull request to have your code reviewed and merged.
+
+**For internal contributor:** You can [open a branch](#opening-a-branch) directly
+in this repository. If you don't have the rights, contact the team leader.
+
 
 ## Opening an issue
 
@@ -57,32 +80,7 @@ and a desired outcome). Also provide references to any theoretical work
 to help the reader better understand the feature.
 
 
-## Contributing
-
-Contributions relating to content of the Github repository can be
-submitted through Github pull requests (PR).
-
-PR for bug fixes or new features should be based on the
-[master]{.title-ref} branch.
-
-The following Github documentation may be useful:
-
--   See [Using Pull
-    Requests](https://help.github.com/articles/using-pull-requests) for
-    more information about Pull Requests.
--   See [Fork A Repo](http://help.github.com/forking/) for an
-    introduction to forking a repository.
--   See [Creating
-    branches](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/)
-    for an introduction on branching within GitHub.
-
-**For external contributors:** Please fork this repository, make the desired
-changes, and open a Pull request to have your code reviewed and merged.
-
-**For internal contributor:** You can [open a branch](#opening-a-branch) directly
-in this repository. If you don't have the rights, contact the team leader.
-
-### Opening a Branch
+## Opening a Branch
 
 If you are part of the core developer team, you can open a branch directly in this
 repository. Prefix the branch name with a personal identifier and a forward slash;
@@ -94,13 +92,14 @@ Examples:
 -   `ol/100-fixup-lr-scheduler`
 -   `ab/loader-pep8`
 
-### Developing
 
-#### Conflicts
+## Developing
+
+### Conflicts
 
 Make sure the PR changes are not in conflict with the master branch.
 
-#### Code style
+### Code style
 
 Please review your changes for styling issues, clarity, according to the
 [PEP8 convention](https://www.python.org/dev/peps/pep-0008/). Correct
@@ -112,7 +111,7 @@ has a code analyser integrated or you can use
 Do not address your functional changes in the same commits as any
 styling clean-up you may be doing on existing code.
 
-#### Documentation and docstrings
+### Documentation and docstrings
 
 If you are implementing a new feature, update the documentation to
 describe the feature, and comment the code (things that are not
@@ -124,28 +123,28 @@ algorithm described in a paper, add pointers to the section / steps.
 
 Please use the [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 
-#### Testing
+### Testing
 
-Please add tests, especially with new code. As of now, we have
-integration tests, and unit tests (in [/testing/]{.title-ref}). They are
-straightforward to augment, but we understand it\'s the extra mile; it
+Please add tests, especially with new code. Unit tests are located under
+`testing/`. They are straightforward to augment, but we understand it's the extra mile; it
 would still be appreciated if you provide something lighter (eg. in the
 commit messages or in the PR or issue text) that demonstrates that an
 issue was fixed, or a feature is functional.
 
 Consider that if you add test cases, they will ensure that your feature
-\-- which you probably care about \-- does not stop working in the
+-- which you probably care about -- does not stop working in the
 future.
 
-#### Licensing
+### Licensing
 
 Ensure that you are the original author of your changes, and if that is
 not the case, ensure that the borrowed/adapted code is compatible with
-the [project's license]().
+the [project's license](https://ivado-medical-imaging.readthedocs.io/en/latest/license.html).
 
-### Committing
 
-#### Commit Titles
+## Committing
+
+### Commit Titles
 
 Provide a concise and self-descriptive title (avoid \> 80 characters).
 You may "scope" the title using the applicable command name(s), folder
@@ -159,8 +158,7 @@ Examples:
     documentation: add slice_axis to the config files
     model: add HeMIS network
 
-#### Commit Sequences
-
+### Commit Sequences
 
 Update your branch to be baseline on the latest master if new
 developments were merged while you were developing. Please prefer
@@ -170,17 +168,16 @@ Note that if you do rebases after review have started, they will be
 cancelled, so at this point it may be more appropriate to do a pull.
 
 Clean-up your commit sequence. If your are not familiar with git, [this
-good
-tutorial](https://www.atlassian.com/git/tutorials/rewriting-history) on
+good tutorial](https://www.atlassian.com/git/tutorials/rewriting-history) on
 the subject may help you.
 
 Focus on committing 1 logical change at a time. See [this
 article](https://github.com/erlang/otp/wiki/writing-good-commit-messages)
 on the subject.
 
-### Submitting a Pull Request
+## Submitting a Pull Request
 
-#### PR Title
+### PR Title
 
 The PR title is used to automatically generate the
 [Changelog](https://github.com/neuropoly/ivado-medical-imaging/blob/master/CHANGES.md)
@@ -193,7 +190,7 @@ for each new release, so please follow the following rules:
 -   If the PR is not ready for review, add \"(WIP)\" at the beginning of
     the title.
 
-#### PR Body
+### PR Body
 
 Describe what the PR is about, explain the approach and possible
 drawbacks. Don\'t hesitate to repeat some of the text from the related
@@ -203,24 +200,22 @@ If the PR fixes issue(s), indicate it after your introduction:
 `Fixes #XXXX, Fixes #YYYY`. Note: it is important to respect the syntax
 above so that the issue(s) will be closed upon merging the PR.
 
-#### Continuous Integration
+### Continuous Integration
 
-The PR can\'t be merged if [Travis
-build](https://travis-ci.org/neuropoly/ivado-medical-imaging) hasn\'t
-succeeded. If you are familiar with it, consult the Travis test results
+The PR can't be merged if [Github Actions "Run tests"](https://github.com/neuropoly/ivado-medical-imaging/actions)
+hasn't succeeded. If you are familiar with it, consult the test results
 and check for possibility of allowed failures.
 
-#### Reviewers
+### Reviewers
 
 Any changes submitted for inclusion to the master branch will have to go
-through a
-[review](https://help.github.com/articles/about-pull-request-reviews/).
+through a [review](https://help.github.com/articles/about-pull-request-reviews/).
 
 Only request a review when you deem the PR as "good to go". If the PR is
-not ready for review, add \"(WIP)\" at the beginning of the title.
+not ready for review, convert it to a "Draft".
 
 Github may suggest you to add particular reviewers to your PR. If
-that\'s the case and you don\'t know better, add all of these
+that's the case and you don't know better, add all of these
 suggestions. The reviewers will be notified when you add them.
 
 ## Versioning
@@ -228,7 +223,7 @@ suggestions. The reviewers will be notified when you add them.
 Versioning uses the following convention: MAJOR.MINOR.PATCH, where:
 
 PATCH version when there are backwards-compatible bug fixes or enhancements, without alteration to Python's modules or data/binaries.
-MINOR version when there are minor API changes or new functionality in a backwards-compatible manner, or when there are alteration to Python's modules or data/binaries (which requires to re-run SCT installer for people working on the dev version),
+MINOR version when there are minor API changes or new functionality in a backwards-compatible manner, or when there are alteration to Python's modules or data/binaries (which requires to re-run installer for people working on the dev version),
 MAJOR version when there are major incompatible API changes,
 Beta releases follow the following convention:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,8 +203,8 @@ above so that the issue(s) will be closed upon merging the PR.
 ### Continuous Integration
 
 The PR can't be merged if [Github Actions "Run tests"](https://github.com/neuropoly/ivado-medical-imaging/actions)
-hasn't succeeded. If you are familiar with it, consult the test results
-and check for possibility of allowed failures.
+hasn't succeeded. If you are familiar with it, consult the test results to fix
+the problem. 
 
 ### Reviewers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,19 @@
+# Contributing to ivadomed
 
+## Introduction
 
-# Contributing to IVADO Medical Imaging
+First off, thanks for taking the time to contribute! :tada::+1:
 
-## Table of contents
-1. [Introduction](#introduction)
-2. [Opening an issue](#opening-an-issue)
-    1. [Before Submitting a New Issue](#before-submitting-a-new-issue)
-    2. [Submitting an Issue](#submitting-an-issue)
-3. [Contributing to IVADO Medical Imaging (Pull request)](#contributing-to-ivado-medical-imaging-pull-request)
-    1. [Opening a Branch](#opening-a-branch)
-    2. [Naming your Branch](#naming-your-branch)
-    3. [Developing](#developing)
-        1. [Documentation and docstrings](#documentation-and-docstrings)
-        2. [Code style](#code-style)
-    4. [Committing](#committing)
-    5. [Submitting a Pull Request](#submitting-a-pull-request)
-4. [Versioning](#versioning)
-
-## Introduction 
-
-
-Thank you for contributing to IVADO Medical Imaging! Examples of contribution include:
-
-- Reporting issues you encounter
-
-- Providing new code or other content into the IVADO Medical Imaging repositories
-
-- Contributing to the wiki or mailing list
+When contributing to this repository, please first discuss the change you wish
+to make via Github issue, email, or any other method with the core team before
+making a change.
 
 
 ## Opening an issue
 
-
-
 Issues (bugs, feature requests, or others) can be submitted [on our project's issue page.](https://github.com/neuropoly/ivado-medical-imaging/issues)
 
-
 ### Before Submitting a New Issue
-
 
 Please take a few seconds to search the issue database in case the
 issue has already been raised.
@@ -46,15 +22,12 @@ When reporting an issue, make sure your installation has not been tempered
 with (and if you can, update to the latest release, maybe the problem was
 fixed).
 
-
 ### Submitting an Issue
-
 
 #### Issue Title
 
 Try to have a self-descriptive, meaningful issue title, summarizing the
-problem you see. Do not add the function name, because this will be
-taken care of by the [Issue Labels]().
+problem you see.
 
 Examples:
 
@@ -62,7 +35,6 @@ Examples:
 -   *Add a special mode for multi-class segmentation*
 
 #### Issue Body
-
 
 **Describe** the issue and mention the IVADO Medical Imaging version and
 OS that you are using.
@@ -84,16 +56,16 @@ how the feature would be used (ideally inputs, a sequence of commands,
 and a desired outcome). Also provide references to any theoretical work
 to help the reader better understand the feature.
 
-## Contributing to IVADO Medical Imaging (Pull request)
 
+## Contributing
 
-Contributions relating to content of the github repository can be
-submitted through github pull requests (PR).
+Contributions relating to content of the Github repository can be
+submitted through Github pull requests (PR).
 
 PR for bug fixes or new features should be based on the
 [master]{.title-ref} branch.
 
-The following github documentation may be useful:
+The following Github documentation may be useful:
 
 -   See [Using Pull
     Requests](https://help.github.com/articles/using-pull-requests) for
@@ -104,17 +76,16 @@ The following github documentation may be useful:
     branches](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/)
     for an introduction on branching within GitHub.
 
+**For external contributors:** Please fork this repository, make the desired
+changes, and open a Pull request to have your code reviewed and merged.
+
+**For internal contributor:** You can [open a branch](#opening-a-branch) directly
+in this repository. If you don't have the rights, contact the team leader.
+
 ### Opening a Branch
 
-
-If you are in the [Official list of
-contributors](https://github.com/neuropoly/ivado-medical-imaging/people?affiliation=ALL)
-please open a branch inside [SCT\'s official
-repository](https://github.com/neuropoly/ivado-medical-imaging)
-
-### Naming your Branch
-
-Prefix the branch name with a personal identifier and a forward slash;
+If you are part of the core developer team, you can open a branch directly in this
+repository. Prefix the branch name with a personal identifier and a forward slash;
 If the branch you are working on is in response to an issue, provide the
 issue number; Add some text that make the branch name meaningful.
 
@@ -122,7 +93,6 @@ Examples:
 
 -   `ol/100-fixup-lr-scheduler`
 -   `ab/loader-pep8`
-
 
 ### Developing
 
@@ -171,8 +141,7 @@ future.
 
 Ensure that you are the original author of your changes, and if that is
 not the case, ensure that the borrowed/adapted code is compatible with
-the MIT license.
-
+the [project's license]().
 
 ### Committing
 
@@ -211,9 +180,7 @@ on the subject.
 
 ### Submitting a Pull Request
 
-
 #### PR Title
-
 
 The PR title is used to automatically generate the
 [Changelog](https://github.com/neuropoly/ivado-medical-imaging/blob/master/CHANGES.md)
@@ -223,12 +190,10 @@ for each new release, so please follow the following rules:
     Title](#issue-title)).
 -   Do not include the applicable issue number in the title (do it in
     the [PR Body](#pr-body)).
--   Do not include the function name (use a [PR Labels]() instead).
 -   If the PR is not ready for review, add \"(WIP)\" at the beginning of
     the title.
 
 #### PR Body
-
 
 Describe what the PR is about, explain the approach and possible
 drawbacks. Don\'t hesitate to repeat some of the text from the related
@@ -240,14 +205,12 @@ above so that the issue(s) will be closed upon merging the PR.
 
 #### Continuous Integration
 
-
 The PR can\'t be merged if [Travis
 build](https://travis-ci.org/neuropoly/ivado-medical-imaging) hasn\'t
 succeeded. If you are familiar with it, consult the Travis test results
 and check for possibility of allowed failures.
 
 #### Reviewers
-
 
 Any changes submitted for inclusion to the master branch will have to go
 through a
@@ -271,4 +234,3 @@ Beta releases follow the following convention:
 
 MAJOR.MINOR.PATCH-beta.x (with x = 0, 1, 2, etc.)
 Stable version is indicated in the file version.txt. For development version (on master), the version is "dev".
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@
     1. [Opening a Branch](#opening-a-branch)
     2. [Naming your Branch](#naming-your-branch)
     3. [Developing](#developing)
+        1. [Documentation and docstrings](#documentation-and-docstrings)
+        2. [Code style](#code-style)
     4. [Committing](#committing)
     5. [Submitting a Pull Request](#submitting-a-pull-request)
 4. [Versioning](#versioning)
@@ -121,18 +123,38 @@ Examples:
 -   `ol/100-fixup-lr-scheduler`
 -   `ab/loader-pep8`
 
-### Developing
 
+### Developing
 
 #### Conflicts
 
+Make sure the PR changes are not in conflict with the master branch.
 
-Make sure the PR changes are not in conflict with the documentation,
-either documentation files ([/README.md]{.title-ref},
-[/wiki/]{.title-ref}).
+#### Code style
+
+Please review your changes for styling issues, clarity, according to the
+[PEP8 convention](https://www.python.org/dev/peps/pep-0008/). Correct
+any code style suggested by an analyzer on your changes.
+[PyCharm](https://www.jetbrains.com/help/pycharm/2016.1/code-inspection.html)
+has a code analyser integrated or you can use
+[pyflakes](https://github.com/PyCQA/pyflakes).
+
+Do not address your functional changes in the same commits as any
+styling clean-up you may be doing on existing code.
+
+#### Documentation and docstrings
+
+If you are implementing a new feature, update the documentation to
+describe the feature, and comment the code (things that are not
+trivially understandable from the code) to improve its maintainability.
+
+Make sure to cite any papers, algorithms or articles that can help
+understand the implementation of the feature. If you are implementing an
+algorithm described in a paper, add pointers to the section / steps.
+
+Please use the [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 
 #### Testing
-
 
 Please add tests, especially with new code. As of now, we have
 integration tests, and unit tests (in [/testing/]{.title-ref}). They are
@@ -145,41 +167,16 @@ Consider that if you add test cases, they will ensure that your feature
 \-- which you probably care about \-- does not stop working in the
 future.
 
-#### Documentation
-
-
-If you are implementing a new feature, update the documentation to
-describe the feature, and comment the code (things that are not
-trivially understandable from the code) to improve its maintainability.
-
-Make sure to cite any papers, algorithms or articles that can help
-understand the implementation of the feature. If you are implementing an
-algorithm described in a paper, add pointers to the section / steps.
-
-#### Code style
-
-
-Please review your changes for styling issues, clarity, according to the
-[PEP8 convention](https://www.python.org/dev/peps/pep-0008/). Correct
-any code style suggested by an analyzer on your changes.
-[PyCharm](https://www.jetbrains.com/help/pycharm/2016.1/code-inspection.html)
-has a code analyser integrated or you can use
-[pyflakes](https://github.com/PyCQA/pyflakes).
-
-Do not address your functional changes in the same commits as any
-styling clean-up you may be doing on existing code.
-
 #### Licensing
 
 Ensure that you are the original author of your changes, and if that is
 not the case, ensure that the borrowed/adapted code is compatible with
 the MIT license.
 
+
 ### Committing
 
-
 #### Commit Titles
-
 
 Provide a concise and self-descriptive title (avoid \> 80 characters).
 You may "scope" the title using the applicable command name(s), folder

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,8 +187,7 @@ for each new release, so please follow the following rules:
     Title](#issue-title)).
 -   Do not include the applicable issue number in the title (do it in
     the [PR Body](#pr-body)).
--   If the PR is not ready for review, add \"(WIP)\" at the beginning of
-    the title.
+-   If the PR is not ready for review, convert it to a draft.
 
 ### PR Body
 

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -1,0 +1,1 @@
+../../CONTRIBUTING.md

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -17,11 +17,9 @@ Contents
 * [Getting started](getting_started.md)
 * [Tutorials](tutorials.md)
 * [Data](data.md)
+* [Contributing](contributing.md)
 * [API Reference](api_ref.rst)
 
-
 ## Support
-
-## Contributing
 
 ## License

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -19,7 +19,6 @@ Contents
 * [Data](data.md)
 * [Contributing](contributing.md)
 * [API Reference](api_ref.rst)
+* [License](license.rst)
 
 ## Support
-
-## License

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -1,0 +1,4 @@
+License
+=======
+
+.. include:: ../../LICENSE.md

--- a/docs/source/tutorials.md
+++ b/docs/source/tutorials.md
@@ -1,13 +1,4 @@
-# Test2
+# Tutorials
 
-yooooooo
-
-## yay
-
-~~~
-code!
-~~~
-
-## boo
-
-fdf
+``` warning:: Will come soon.
+```


### PR DESCRIPTION
Changes include:
- Added symlinks for CONTRIBUTING and LICENSE under docs/ to be able to include them in the docs build;
- Added Contributing and License in the documentation TOC;
- Updated CONTRIBUTING.md:
  - Fix a few issues and clarify things
  - Added docstrings convention info (Google style). Fixes #156 