### PR TITLE
Adapt loader to slice-wise classification task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ future.
 
 Ensure that you are the original author of your changes, and if that is
 not the case, ensure that the borrowed/adapted code is compatible with
-the [project's license](https://ivado-medical-imaging.readthedocs.io/en/latest/license.html).
+the [project's license](https://ivadomed.org/en/latest/index.html#license).
 
 
 ## Committing

--- a/ivadomed/config/config_classification.json
+++ b/ivadomed/config/config_classification.json
@@ -1,0 +1,106 @@
+{
+    "command": "train",
+    "gpu": 6,
+    "log_directory": "sct_testing_lesion_ax",
+    "debugging": false,
+    "loader_parameters": {
+        "bids_path": "../duke/sct_testing/large/",
+        "target_suffix": ["_lesion-manual"],
+        "detection_params": {
+            "applied": true,
+            "model_path": null
+        },
+        "roi_params": {
+            "suffix": "_seg-manual",
+            "slice_filter_roi": 10
+        },
+        "contrast_params": {
+            "training_validation": ["acq-ax00012_T2w", "acq-axtop00100_T2w", "acq-axtsp_T2w", "acq-c4c7_T2star", "acq-axmid00100_T2w", "acq-axlow_T2w", "acq-sup_T2w", "acq-ax_T2star", "acq-inf_T2star", "acq-ax_T2w", "acq-axcsp_T2w", "acq-c1c3_T2star", "T2star", "acq-axtop_T2w", "acq-axbottom_T2w", "acq-ax00014_T2w", "T2w", "acq-sup_T2star", "acq-axmid00005_T2w", "acq-inf_T2w"],
+            "testing": ["acq-ax00012_T2w", "acq-axtop00100_T2w", "acq-axtsp_T2w", "acq-c4c7_T2star", "acq-axmid00100_T2w", "acq-axlow_T2w", "acq-sup_T2w", "acq-ax_T2star", "acq-inf_T2star", "acq-ax_T2w", "acq-axcsp_T2w", "acq-c1c3_T2star", "T2star", "acq-axtop_T2w", "acq-axbottom_T2w", "acq-ax00014_T2w", "T2w", "acq-sup_T2star", "acq-axmid00005_T2w", "acq-inf_T2w"],
+            "balance": {}
+        },
+        "slice_filter_params": {
+            "filter_empty_mask": false,
+            "filter_empty_input": true
+        },
+        "slice_axis": "axial",
+        "multichannel": false
+    },
+    "split_dataset": {
+        "fname_split": null,
+        "random_seed": 6,
+        "center_test": [],
+        "method": "per_patient",
+        "train_fraction": 0.6,
+        "test_fraction": 0.2
+    },
+    "training_parameters": {
+        "batch_size": 64,
+        "loss": {
+            "name": "DiceLoss"
+        },
+        "training_time": {
+            "num_epochs": 100,
+            "early_stopping_patience": 50,
+            "early_stopping_epsilon": 0.001
+        },
+        "scheduler": {
+            "initial_lr": 0.001,
+            "lr_scheduler": {
+                "name": "CyclicLR",
+                "base_lr": 0.0001,
+                "max_lr": 0.001
+            }
+        },
+        "balance_samples": false,
+        "mixup_alpha": null,
+        "transfer_learning": {
+            "retrain_model": null,
+            "retrain_fraction": 1.0
+        }
+    },
+    "default_model": {
+        "name": "Unet",
+        "dropout_rate": 0.3,
+        "bn_momentum": 0.9,
+        "depth": 2
+    },
+    "testing_parameters": {
+        "binarize_prediction": true,
+        "uncertainty": {
+            "epistemic": false,
+            "aleatoric": false,
+            "n_it": 0
+        }
+    },
+    "evaluation_parameters": {
+        "targetSize": {"unit": "vox", "thr": [20, 100]},
+        "removeSmall": {"unit": "vox", "thr": 3},
+        "overlap": {"unit": "vox", "thr": 3}
+    },
+    "transformation": {
+        "Resample":
+        {
+            "wspace": 0.75,
+            "hspace": 0.75,
+            "dspace": 1
+        },
+        "ROICrop": {
+            "size": [48, 48]
+        },
+        "RandomTranslation": {
+            "translate": [0.03, 0.03],
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+        "ElasticTransform": {
+			"alpha_range": [28.0, 30.0],
+			"sigma_range":  [3.5, 4.5],
+			"p": 0.1,
+            "applied_to": ["im"],
+            "dataset_type": ["training"]
+        },
+      "NumpyToTensor": {"applied_to": ["im"]},
+      "NormalizeInstance": {"applied_to": ["im"]}
+    }
+}

--- a/ivadomed/config/config_classification.json
+++ b/ivadomed/config/config_classification.json
@@ -1,7 +1,7 @@
 {
     "command": "train",
     "gpu": 6,
-    "log_directory": "sct_testing_lesion_ax",
+    "log_directory": "classification_lesion_ax",
     "debugging": false,
     "loader_parameters": {
         "bids_path": "../duke/sct_testing/large/",

--- a/ivadomed/config/config_classification.json
+++ b/ivadomed/config/config_classification.json
@@ -82,10 +82,12 @@
         {
             "wspace": 0.75,
             "hspace": 0.75,
-            "dspace": 1
+            "dspace": 1,
+            "applied_to": ["im", "roi"]
         },
         "ROICrop": {
-            "size": [48, 48]
+            "size": [48, 48],
+            "applied_to": ["im"]
         },
         "RandomTranslation": {
             "translate": [0.03, 0.03],

--- a/ivadomed/config/config_classification.json
+++ b/ivadomed/config/config_classification.json
@@ -6,10 +6,6 @@
     "loader_parameters": {
         "bids_path": "../duke/sct_testing/large/",
         "target_suffix": ["_lesion-manual"],
-        "detection_params": {
-            "applied": true,
-            "model_path": null
-        },
         "roi_params": {
             "suffix": "_seg-manual",
             "slice_filter_roi": 10
@@ -64,6 +60,9 @@
         "dropout_rate": 0.3,
         "bn_momentum": 0.9,
         "depth": 2
+    },
+    "NAME_CLASSIFIER_1": {
+        "applied": true
     },
     "testing_parameters": {
         "binarize_prediction": true,

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -272,7 +272,10 @@ class SegmentationPair(object):
                     gt_slices.append(np.asarray(gt_obj[..., slice_index],
                                                 dtype=np.float32))
                 else:
-                    pass
+                    # TODO_future: Deal with non binary classification, eg get np.max(slice)
+                    # Note_CG: I initially went with int(not np.any(gt_obj[..., slice_index])) but changed it to handle
+                    #   non binary classification
+                    gt_slices.append(int(np.max(gt_obj[..., slice_index])))
 
         dreturn = {
             "input": input_slices,

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -382,8 +382,9 @@ class MRI2DSegmentationDataset(Dataset):
         stack_gt, metadata_gt = self.transform(sample=seg_pair_slice["gt"],
                                                metadata=metadata_gt,
                                                data_type="gt")
+        print(stack_gt)
         # Make sure stack_gt is binarized
-        if stack_gt is not None:
+        if stack_gt is not None and self.task == "segmentation":
             stack_gt = torch.as_tensor(
                 [imed_postpro.threshold_predictions(stack_gt[i_label, :], thr=0.1) for i_label in range(len(stack_gt))])
 

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -111,7 +111,6 @@ class SegmentationPair(object):
         self.metadata = metadata
         self.cache = cache
         self.slice_axis = slice_axis
-        self.task = task
 
         # list of the images
         self.input_handle = []
@@ -272,7 +271,8 @@ class SegmentationPair(object):
                     gt_slices.append(np.asarray(gt_obj[..., slice_index],
                                                 dtype=np.float32))
                 else:
-                    # TODO_future: Deal with non binary classification, eg get np.max(slice)
+                    # Assert that there is only one non_zero_label in the current slice
+                    assert len(gt_obj[..., slice_index][np.nonzero(gt_obj[..., slice_index])].tolist()) <= 1
                     # Note_CG: I initially went with int(not np.any(gt_obj[..., slice_index])) but changed it to handle
                     #   non binary classification
                     gt_slices.append(int(np.max(gt_obj[..., slice_index])))

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -94,22 +94,26 @@ def load_dataset(data_list, bids_path, transforms_params, model_params, target_s
 class SegmentationPair(object):
     """This class is used to build segmentation datasets. It represents
     a pair of of two data volumes (the input data and the ground truth data).
-
-    :param input_filenames: the input filename list (supported by nibabel). For single channel, the list will contain 1
-                           input filename.
-    :param gt_filenames: the ground-truth filenames list.
-    :param metadata: metadata list with each item corresponding to an image (modality) in input_filenames.  For single
-                     channel, the list will contain metadata related to one image.
-    :param cache: if the data should be cached in memory or not.
     """
 
-    def __init__(self, input_filenames, gt_filenames, metadata=None, slice_axis=2, cache=True):
-
+    def __init__(self, input_filenames, gt_filenames, metadata=None, slice_axis=2, cache=True, task="segmentation"):
+        """
+        Args:
+            input_filenames (list): the input filename list (supported by nibabel). For single channel, the list will
+                contain 1 input filename.
+            gt_filenames (list): the ground-truth filenames list.
+            metadata (list): metadata list with each item corresponding to an image (modality) in input_filenames.
+                For single channel, the list will contain metadata related to one image.
+            cache (bool): if the data should be cached in memory or not.
+            task (string): choice between segmentation or classification. If classification: GT is discrete values.
+                If segmentation: GT is binary mask.
+        """
         self.input_filenames = input_filenames
         self.gt_filenames = gt_filenames
         self.metadata = metadata
         self.cache = cache
         self.slice_axis = slice_axis
+        self.task = task
 
         # list of the images
         self.input_handle = []
@@ -303,11 +307,12 @@ class MRI2DSegmentationDataset(Dataset):
 
     def _load_filenames(self):
         for input_filenames, gt_filenames, roi_filename, metadata in self.filename_pairs:
+            # Note: We force task=segmentation for ROI because we need the ROI mask to perform the im cropping
             roi_pair = SegmentationPair(input_filenames, roi_filename, metadata=metadata, slice_axis=self.slice_axis,
-                                        cache=self.cache)
+                                        cache=self.cache, task="segmentation")
 
             seg_pair = SegmentationPair(input_filenames, gt_filenames, metadata=metadata, slice_axis=self.slice_axis,
-                                        cache=self.cache)
+                                        cache=self.cache, task=self.task)
 
             input_data_shape, _ = seg_pair.get_pair_shapes()
 

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -275,17 +275,21 @@ class SegmentationPair(object):
 
 
 class MRI2DSegmentationDataset(Dataset):
-    """This is a generic class for 2D (slice-wise) segmentation datasets.
+    """This is a generic class for 2D (slice-wise) segmentation datasets."""
 
-    :param filename_pairs: a list of tuples in the format (input filename list containing all modalities,
-                           ground truth filename, ROI filename, metadata).
-    :param slice_axis: axis to make the slicing (default axial).
-    :param cache: if the data should be cached in memory or not.
-    :param transform: transformations to apply.
-    """
-
-    def __init__(self, filename_pairs, slice_axis=2, cache=True, transform=None, slice_filter_fn=None):
-
+    def __init__(self, filename_pairs, slice_axis=2, cache=True, transform=None, slice_filter_fn=None,
+                 task="segmentation"):
+        """
+        Args
+            filename_pairs (list): a list of tuples in the format (input filename list containing all modalities,ground
+                truth filename, ROI filename, metadata).
+            slice_axis (int): axis to make the slicing (default axial).
+            cache (bool): if the data should be cached in memory or not.
+            transform (torchvision.Compose): transformations to apply.
+            slice_filter_fn ():
+            task (string): choice between segmentation or classification. If classification: GT is discrete values.
+                If segmentation: GT is binary mask.
+        """
         self.indexes = []
         self.filename_pairs = filename_pairs
         self.transform = transform
@@ -293,6 +297,7 @@ class MRI2DSegmentationDataset(Dataset):
         self.slice_axis = slice_axis
         self.slice_filter_fn = slice_filter_fn
         self.n_contrasts = len(self.filename_pairs[0][0])
+        self.task = task
 
         self._load_filenames()
 
@@ -632,4 +637,4 @@ class BidsDataset(MRI2DSegmentationDataset):
                     self.filename_pairs.append((subject["absolute_paths"], subject["deriv_path"],
                                                 subject["roi_filename"], subject["metadata"]))
 
-        super().__init__(self.filename_pairs, slice_axis, cache, transform, slice_filter_fn)
+        super().__init__(self.filename_pairs, slice_axis, cache, transform, slice_filter_fn, task)

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -274,7 +274,7 @@ class SegmentationPair(object):
                     # Assert that there is only one non_zero_label in the current slice
                     labels_in_slice = np.unique(gt_obj[..., slice_index][np.nonzero(gt_obj[..., slice_index])]).tolist()
                     if len(labels_in_slice) > 1:
-                        print(metadata["gt_metadata"])
+                        print(metadata["gt_metadata"][0]["gt_filenames"])
                     #assert len(labels_in_slice) <= 1
                     # We use np.max instead of (not np.any(gt_obj[..., slice_index]) to handle non binary classification
                     gt_slices.append(int(np.max(gt_obj[..., slice_index])))

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -380,15 +380,20 @@ class MRI2DSegmentationDataset(Dataset):
         # Update metadata_input with metadata_roi
         metadata_gt = imed_loader_utils.update_metadata(metadata_input, metadata_gt)
 
-        # Run transforms on images
-        stack_gt, metadata_gt = self.transform(sample=seg_pair_slice["gt"],
-                                               metadata=metadata_gt,
-                                               data_type="gt")
+        if self.task == "segmentation":
+            # Run transforms on images
+            stack_gt, metadata_gt = self.transform(sample=seg_pair_slice["gt"],
+                                                   metadata=metadata_gt,
+                                                   data_type="gt")
+            # Make sure stack_gt is binarized
+            if stack_gt is not None:
+                stack_gt = torch.as_tensor(
+                    [imed_postpro.threshold_predictions(stack_gt[i_label, :], thr=0.1) for i_label in
+                     range(len(stack_gt))])
+        else:
+            # Force no transformation on labels
+            stack_gt = seg_pair_slice["gt"]
         print(stack_gt)
-        # Make sure stack_gt is binarized
-        if stack_gt is not None and self.task == "segmentation":
-            stack_gt = torch.as_tensor(
-                [imed_postpro.threshold_predictions(stack_gt[i_label, :], thr=0.1) for i_label in range(len(stack_gt))])
 
         data_dict = {
             'input': stack_input,

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -17,7 +17,7 @@ from ivadomed.loader import utils as imed_loader_utils, loader as imed_loader, f
 cudnn.benchmark = True
 
 # List of not-default available models i.e. different from Unet
-MODEL_LIST = ['UNet3D', 'HeMISUnet', 'FiLMedUnet']
+MODEL_LIST = ['UNet3D', 'HeMISUnet', 'FiLMedUnet', 'NAME_CLASSIFIER_1']
 
 
 def run_main():
@@ -58,11 +58,6 @@ def run_main():
         loader_params["contrast_params"]["contrast_lst"] = loader_params["contrast_params"]["testing"]
     if "FiLMedUnet" in context and context["FiLMedUnet"]["applied"]:
         loader_params.update({"metadata_type": context["FiLMedUnet"]["metadata"]})
-
-    # Task selection
-    # TODO: add distinction between classification and BBbox detections
-    print("\nTask: {}.\n".format("Classification" if loader_params["detection_params"]["applied"] else "Segmentation"))
-    # QUESTION: Do we want to force applied=im (not gt) in transforms if classification? or do we trust ourselves?
 
     # Get transforms for each subdataset
     transform_train_params, transform_valid_params, transform_test_params = \

--- a/ivadomed/main.py
+++ b/ivadomed/main.py
@@ -50,15 +50,6 @@ def run_main():
                                                                                      context['loader_parameters']['bids_path'],
                                                                                      log_directory)
 
-    # Get transforms for each subdataset
-    transform_train_params, transform_valid_params, transform_test_params = \
-        imed_transforms.get_subdatasets_transforms(context["transformation"])
-    if command == "train":
-        imed_utils.display_selected_transfoms(transform_train_params, dataset_type="training")
-        imed_utils.display_selected_transfoms(transform_valid_params, dataset_type="validation")
-    elif command == "test":
-        imed_utils.display_selected_transfoms(transform_test_params, dataset_type="testing")
-
     # Loader params
     loader_params = context["loader_parameters"]
     if command == "train":
@@ -67,6 +58,20 @@ def run_main():
         loader_params["contrast_params"]["contrast_lst"] = loader_params["contrast_params"]["testing"]
     if "FiLMedUnet" in context and context["FiLMedUnet"]["applied"]:
         loader_params.update({"metadata_type": context["FiLMedUnet"]["metadata"]})
+
+    # Task selection
+    # TODO: add distinction between classification and BBbox detections
+    print("\nTask: {}.\n".format("Classification" if loader_params["detection_params"]["applied"] else "Segmentation"))
+    # QUESTION: Do we want to force applied=im (not gt) in transforms if classification? or do we trust ourselves?
+
+    # Get transforms for each subdataset
+    transform_train_params, transform_valid_params, transform_test_params = \
+        imed_transforms.get_subdatasets_transforms(context["transformation"])
+    if command == "train":
+        imed_utils.display_selected_transfoms(transform_train_params, dataset_type="training")
+        imed_utils.display_selected_transfoms(transform_valid_params, dataset_type="validation")
+    elif command == "test":
+        imed_utils.display_selected_transfoms(transform_test_params, dataset_type="testing")
 
     # METRICS
     metric_fns = [imed_metrics.dice_score,


### PR DESCRIPTION
## Aim:
Adapt 2D loader to handle slice-wise classification task.

## Changes:
- Add a config file, `config_classification.json` dedicated to this task.
    - For now, the only change is the addition of this dict, which will contains the classifier params:
```json
    "NAME_CLASSIFIER_1": {
        "applied": true
    },
```
the `"applied": true` triggers the classification task given that this model name is listed [here](https://github.com/neuropoly/ivado-medical-imaging/blob/47db357d37e72a9174b0ee501c63f52fed26a580/ivadomed/loader/loader.py#L14), as part of the classifiers available on the repo'.
- the main consequence of triggering the classification task is that the ground truth is not a mask (array) but a label: does the slice contain the object of interest? Yes / No --> 1 / 0

## Comments:
- the implementation is robust to multi_label classification: eg `target_suffix=["_c2.nii.gz", "_c3.nii.gz"]`, then `stack_gt` is a 2 elements list, with values 0 or 1 ([here](https://github.com/neuropoly/ivado-medical-imaging/blob/47db357d37e72a9174b0ee501c63f52fed26a580/ivadomed/loader/loader.py#L281))
- in `config_classification.json`, I setup transformations for images only (ie not applied to GT) since we deal here with labels, not images. But, if classification task is detected, the loader forces no transformations on the labels anyway ([here](https://github.com/neuropoly/ivado-medical-imaging/blob/47db357d37e72a9174b0ee501c63f52fed26a580/ivadomed/loader/loader.py#L396)).

## TODO before merging
After PR approval but before merging:
- Fill wiki config doc'