### PR TITLE
Fix sphinx warnings when building documentation

### DIFF
--- a/docs/source/api_ref.rst
+++ b/docs/source/api_ref.rst
@@ -50,7 +50,7 @@ This document is for developers of ``ivadomed``, it contains the API functions.
 ----------------------
 
 .. autoclass:: ivadomed.losses.MultiClassDiceLoss
-.. automethod:: ivadomed.losses.dice_loss
+.. autoclass:: ivadomed.losses.DiceLoss
 .. autoclass:: ivadomed.losses.FocalLoss
 .. autoclass:: ivadomed.losses.FocalDiceLoss
 .. autoclass:: ivadomed.losses.GeneralizedDiceLoss

--- a/docs/source/api_ref.rst
+++ b/docs/source/api_ref.rst
@@ -19,8 +19,8 @@ This document is for developers of ``ivadomed``, it contains the API functions.
 
 .. automethod:: ivadomed.loader.film.normalize_metadata
 .. autoclass:: ivadomed.loader.film.Kde_model
-.. autoclass:: ivadomed.loader.film.clustering_fit
-.. autoclass:: ivadomed.loader.film.check_isMRIparam
+.. automethod:: ivadomed.loader.film.clustering_fit
+.. automethod:: ivadomed.loader.film.check_isMRIparam
 
 :mod:`ivadomed.loader.loader`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ivadomed/loader/loader.py
+++ b/ivadomed/loader/loader.py
@@ -299,14 +299,14 @@ class MRI2DSegmentationDataset(Dataset):
     def __init__(self, filename_pairs, slice_axis=2, cache=True, transform=None, slice_filter_fn=None,
                  task="segmentation"):
         """
-        Args
-            filename_pairs (list): a list of tuples in the format (input filename list containing all modalities,ground
+        Args:
+            filename_pairs (list): a list of tuples in the format (input filename list containing all modalities,ground \
                 truth filename, ROI filename, metadata).
             slice_axis (int): axis to make the slicing (default axial).
             cache (bool): if the data should be cached in memory or not.
             transform (torchvision.Compose): transformations to apply.
             slice_filter_fn ():
-            task (string): choice between segmentation or classification. If classification: GT is discrete values.
+            task (string): choice between segmentation or classification. If classification: GT is discrete values, \
                 If segmentation: GT is binary mask.
         """
         self.indexes = []


### PR DESCRIPTION
Root cause: `clustering_fit()` and `check_isMRIparam()` are methods not classes.

closes #252 